### PR TITLE
Add `revitRelease` branch config to GitVersion.yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -14,7 +14,10 @@ branches:
         regex: (^test$)
         tag: alpha
 #        track-merge-target: true
-        
+    revitRelease:
+        increment: Patch
+        regex: ^revit20.*
+        tag: ''        
 ignore:
   sha: []
 merge-message-formats: {}


### PR DESCRIPTION
Added a new branch configuration `revitRelease` to the `GitVersion.yml` file. This configuration applies to branches matching the `^revit20.*` pattern, increments the patch version, and does not include a tag.

Also removed an unnecessary empty line for improved formatting.