### PR TITLE
Rename `revitRelease` branch to `release` in GitVersion.yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -14,11 +14,12 @@ branches:
         regex: (^test$)
         tag: alpha
 #        track-merge-target: true
-    revitRelease:
+    release:
         increment: Patch
         regex: ^revit20.*
         tag: ''
-        source-branches: ['main']        
+        source-branches:
+        - main        
 ignore:
   sha: []
 merge-message-formats: {}


### PR DESCRIPTION
The `revitRelease` branch configuration has been renamed to `release`. Additionally, the `source-branches` property under the `release` branch has been reformatted from a single-line array to a multi-line array for improved readability. No functional changes were made to the `feature` branch configuration, and the `ignore` and `merge-message-formats` sections remain unchanged.