### PR TITLE
Improve TryGetStream robustness with child storage check

### DIFF
--- a/Source/Scotec.Revit/RevitFamily/RevitFamilyInfo.cs
+++ b/Source/Scotec.Revit/RevitFamily/RevitFamilyInfo.cs
@@ -348,7 +348,12 @@ public class RevitFamilyInfo
             return true;
         }
 
-        return TryGetStream(storage, path[1..], out stream);
+        if (storage.TryOpenStorage(path[0], out var childStorage))
+        {
+            return TryGetStream(childStorage, path[1..], out stream);
+        }
+        
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Previously, the TryGetStream method relied on recursive calls to handle paths. This update adds a conditional check to attempt opening a child storage using the first path element. If successful, the method recursively processes the remaining path. If no valid stream is found, the method now explicitly returns false, making the behavior more predictable and easier to debug.