### PR TITLE
Implement IDisposable in RevitFamilyInfo for resource cleanup

### DIFF
--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -24,6 +24,7 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
 		<PackageReference Include="OpenMcdf" Version="3.1.0" />
 		<PackageReference Include="Scotec.Extensions.Utilities" Version="1.1.0" />
+		<PackageReference Include="Scotec.Extensions.Linq" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Enhanced the `RevitFamilyInfo` class to implement the `IDisposable` interface, ensuring proper management and cleanup of unmanaged resources. Added a `Dispose` pattern to release streams and other disposable objects, preventing memory leaks.

- Introduced `Dispose(bool disposing)` and `Dispose()` methods.
- Removed explicit disposal of `infoStream` in favor of the new `Dispose` implementation.
- Added `Scotec.Extensions.Linq` dependency for LINQ extensions (e.g., `ForAll`) used in resource cleanup.
- Updated `Scotec.Revit.csproj` to include the new package reference for `Scotec.Extensions.Linq`.