### PR TITLE
Clarify Revit API threading rules and update factory class

### DIFF
--- a/Documentation/RevitTask.md
+++ b/Documentation/RevitTask.md
@@ -7,8 +7,6 @@ schedule and run code that interacts with the Revit API, regardless of
 whether your calling code is on the Revit UI thread, a background
 thread, or from an external UI (such as WPF or WinForms).
 
-------------------------------------------------------------------------
-
 ## Understanding IExternalEventHandler and the Revit API Context
 
 ### Why is IExternalEventHandler Needed?
@@ -94,12 +92,8 @@ revitTask.Dispose();
 
 ## Threading and Context
 
-Revit is single-threaded with respect to its API.
-
-Even if your code runs on the main Windows UI thread, that does not
-automatically mean you are inside a valid Revit API context.
-
-`RevitTask` ensures your delegate is executed inside a proper
+Revit is single-threaded with respect to its API. Even if your code runs on the main Windows UI thread, that does not
+automatically mean you are inside a valid Revit API context. `RevitTask` ensures your delegate is executed inside a proper
 `IExternalEventHandler.Execute` call.
 
 

--- a/Source/Scotec.Revit.Isolation.SourceGenerator/Resources/RevitCommandAvailabilityFactory.template
+++ b/Source/Scotec.Revit.Isolation.SourceGenerator/Resources/RevitCommandAvailabilityFactory.template
@@ -11,7 +11,6 @@ using {2};
 
 namespace {0}
 {{
-    [Transaction(TransactionMode.Manual)]
     public class {1}Factory : IExternalCommandAvailability
     {{
         private readonly IExternalCommandAvailability _instance;


### PR DESCRIPTION
Improved the documentation in `RevitTask.md` by removing redundant formatting and clarifying the threading and context rules for the Revit API. Highlighted the role of `RevitTask` in ensuring proper execution within the `IExternalEventHandler.Execute` call.

Removed the `[Transaction(TransactionMode.Manual)]` attribute from `RevitCommandAvailabilityFactory.template`.