### PR TITLE
Improve shared assembly management guidelines

### DIFF
--- a/Documentation/RevitAddinIsolation.md
+++ b/Documentation/RevitAddinIsolation.md
@@ -261,6 +261,8 @@ This ensures that these assemblies are resolved from the shared context instead 
 
 If an assembly is configured as a shared assembly for one add-in specific load context, it must also be configured as a shared assembly for every other load context that needs to use that assembly. Otherwise, the same assembly may be loaded into different contexts, which can lead to inconsistent or undefined behavior. This is especially important for frameworks such as WPF, where loading the same assembly into multiple contexts can result in type identity issues, resource resolution problems, or other runtime errors.
 
+In practice, shared UI or contract assemblies should be maintained in a central list or shared configuration used by all add-ins to ensure consistent load context behavior.
+
 ---
 
 ## When to Use Shared Contexts


### PR DESCRIPTION
Improve shared assembly management guidelines

Added a recommendation to maintain shared UI or contract assemblies in a central list or shared configuration. This ensures consistent load context behavior across add-ins and prevents issues such as type identity conflicts, resource resolution problems, or runtime errors, particularly in frameworks like WPF.