### PR TITLE
Update package versions for Utilities and Linq

### DIFF
--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -23,8 +23,8 @@
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
 		<PackageReference Include="OpenMcdf" Version="3.1.0" />
-		<PackageReference Include="Scotec.Extensions.Utilities" Version="1.1.0" />
-		<PackageReference Include="Scotec.Extensions.Linq" Version="1.1.0" />
+		<PackageReference Include="Scotec.Extensions.Utilities" Version="1.1.1" />
+		<PackageReference Include="Scotec.Extensions.Linq" Version="1.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update package versions for Utilities and Linq

Upgraded the following package dependencies in `Scotec.Revit.csproj`:
- `Scotec.Extensions.Utilities` from version 1.1.0 to 1.1.1
- `Scotec.Extensions.Linq` from version 1.1.0 to 1.1.1

These updates likely include bug fixes, improvements, or new features.