### PR TITLE
Refactor Revit context initialization logic

### DIFF
--- a/GenerateTest/GenerateTest/Class1.cs
+++ b/GenerateTest/GenerateTest/Class1.cs
@@ -6,7 +6,7 @@ using Scotec.Revit;
 using Scotec.Revit.Isolation;
 using System.Runtime.Loader;
 
-[assembly: RevitAddinIsolationContext(ContextName = "My.Addin.Comtext", SharedContextName = "UI.Context")]
+//[assembly: RevitAddinIsolationContext(ContextName = "My.Addin.Comtext", SharedContextName = "UI.Context")]
 [assembly: RevitSharedIsolationContext("UI.Context")]
 
 namespace GenerateTest;
@@ -48,12 +48,12 @@ partial class RevitAddinAssemblyLoadContext
 }
 
               
-partial class RevitSharedAssemblyLoadContext
-{
-    partial void OnInitialize()
-    {
-    }
-}
+//partial class RevitSharedAssemblyLoadContext
+//{
+//    partial void OnInitialize()
+//    {
+//    }
+//}
 
 [RevitCommandIsolation(ContextName = "TestContext3")]
 [RevitTransactionMode(Mode = RevitTransactionMode.TransactionGroup)]

--- a/Source/Scotec.Revit.Isolation.SourceGenerator/Resources/RevitAssemblyLoadContextInitializer.template
+++ b/Source/Scotec.Revit.Isolation.SourceGenerator/Resources/RevitAssemblyLoadContextInitializer.template
@@ -37,19 +37,23 @@ internal static class RevitAddinModuleInitializer
         var contextName = "{2}";
         var useSharedContext = "{3}";
 
+#if ({5})
         // Initialize the shared context if specified and not already present.
         if(!string.IsNullOrEmpty(sharedContextName) && !AssemblyLoadContext.All.Any(alc => alc.Name == sharedContextName))
         {{
             var loadContext = new RevitSharedAssemblyLoadContext(sharedContextName, currentAssembly.Location);
             loadContext.Initialize();
         }}
+#endif
 
+#if ({4})
         // Initialize the per-addin context if specified and not already present.
         if(!string.IsNullOrEmpty(contextName) && !AssemblyLoadContext.All.Any(alc => alc.Name == contextName))
         {{
             var loadContext = new RevitAddinAssemblyLoadContext(contextName, useSharedContext, currentAssembly.Location);
             loadContext.Initialize();
         }}
+#endif
     }}
 }}
 

--- a/Source/Scotec.Revit.Isolation.SourceGenerator/RevitLoadContextGenerator.cs
+++ b/Source/Scotec.Revit.Isolation.SourceGenerator/RevitLoadContextGenerator.cs
@@ -63,16 +63,16 @@ public sealed class RevitLoadContextGenerator : RevitIncrementalGenerator
         sharedContextName ??= string.Empty;
         useSharedContext ??= string.Empty;
 
-        GenerateContextInitializer(context, @namespace, sharedContextName, contextName, useSharedContext);
+        GenerateContextInitializer(context, @namespace, sharedContextName, contextName, useSharedContext, hasAddinContext, hasSharedContext);
     }
 
     private static void GenerateContextInitializer(SourceProductionContext context, string @namespace, string sharedContextName, string contextName,
-                                                   string usedSharedContextName)
+                                                   string usedSharedContextName, bool hasAddinContext, bool hasSharedContext)
     {
         var template = LoadTemplate("RevitAssemblyLoadContextInitializer");
         if (!string.IsNullOrEmpty(template))
         {
-            var content = string.Format(template, @namespace, sharedContextName, contextName, usedSharedContextName);
+            var content = string.Format(template, @namespace, sharedContextName, contextName, usedSharedContextName, hasAddinContext.ToString(), hasSharedContext.ToString());
             context.AddSource("RevitAssemblyLoadContextInitializer.g.cs", content);
         }
     }


### PR DESCRIPTION
Refactor Revit context initialization logic

Added conditional compilation directives to `RevitAssemblyLoadContextInitializer.template` for controlling shared and per-addin context initialization. Updated `GenerateContextInitializer` in `RevitLoadContextGenerator.cs` to accept `hasAddinContext` and `hasSharedContext` parameters, and adjusted template generation to include these parameters.

These changes enable dynamic and customizable context management, better supporting different isolation scenarios and feature toggling during development or deployment.