### PR TITLE
Add Revit 2027 support and update project configurations

### DIFF
--- a/.github/workflows/Build & Deploy.yml
+++ b/.github/workflows/Build & Deploy.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        revitYear: [2025, 2026]
+        revitYear: [2025, 2026, 2027]
 
     steps:
     - name: Checkout

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        revitYear: [2025, 2026]
+        revitYear: [2025, 2026, 2027]
 
     steps:
     - name: Checkout

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Configurations>Release;Revit2025;Revit2026</Configurations>
+		<Configurations>Release;Revit2025;Revit2026;Revit2027</Configurations>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Revit2025' Or '$(Configuration)' == 'Revit2026' Or '$(Configuration)' == 'Revit2027'">

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -13,7 +13,7 @@
 		<Configurations>Release;Revit2025;Revit2026</Configurations>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)' == 'Revit2025' Or '$(Configuration)' == 'Revit2026'">
+	<PropertyGroup Condition="'$(Configuration)' == 'Revit2025' Or '$(Configuration)' == 'Revit2026' Or '$(Configuration)' == 'Revit2027'">
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>portable</DebugType>
 		<Optimize>false</Optimize>
@@ -25,10 +25,13 @@
 		<RevitYear>2025</RevitYear>
 		<DefineConstants>$(DefineConstants);REVIT2025</DefineConstants>
 	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(Configuration)' == 'Revit2026'">
 		<RevitYear>2026</RevitYear>
 		<DefineConstants>$(DefineConstants);REVIT2026</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)' == 'Revit2027'">
+		<RevitYear>2027</RevitYear>
+		<DefineConstants>$(DefineConstants);REVIT2027</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(RevitYear)' == ''">

--- a/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
+++ b/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
@@ -1,11 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
 		<TargetFramework>net8.0-windows</TargetFramework>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
+
+	<!--<PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	</PropertyGroup>-->
 
 	<PropertyGroup>
 		<Description>Support for Revit add-in isolation.</Description>

--- a/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
+++ b/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
@@ -39,13 +39,29 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(RevitYear)' == '2025'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2025.0.2.419" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
-
 	<ItemGroup Condition="'$(RevitYear)' == '2026'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2026.0.0.9999" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
-
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 	<!--Not working that way.-->
 	<!--<Target Name="PackSourceGenerator" BeforeTargets="Pack">
 		--><!-- Build generator (safe even if already built; MSBuild will incremental-skip) --><!--

--- a/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
+++ b/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
@@ -1,8 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
 		<UseWpf>True</UseWpf>
 	</PropertyGroup>
 

--- a/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
+++ b/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
@@ -45,6 +45,41 @@
 		<None Include="DynamicCommands\RevitDynamicCommandFactory.cs" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(RevitYear)' == '2025'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.AdWindows" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2026'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.AdWindows" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.AdWindows" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
 	</ItemGroup>

--- a/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
+++ b/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
@@ -1,7 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
 		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<UseWpf>True</UseWpf>
 	</PropertyGroup>
 

--- a/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
+++ b/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
@@ -14,6 +14,32 @@
 		<UseWpf>True</UseWpf>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(RevitYear)' == '2025'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2026'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+
 	<ItemGroup>
 		<ProjectReference Include="..\Scotec.Revit.Isolation\Scotec.Revit.Isolation.csproj" />
 		<ProjectReference Include="..\Scotec.Revit\Scotec.Revit.csproj" />

--- a/Source/Scotec.Revit.slnx
+++ b/Source/Scotec.Revit.slnx
@@ -3,6 +3,7 @@
     <BuildType Name="Release" />
     <BuildType Name="Revit2025" />
     <BuildType Name="Revit2026" />
+    <BuildType Name="Revit2027" />
     <Platform Name="x64" />
   </Configurations>
   <Folder Name="/SolutionItems/">

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -21,14 +21,23 @@
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(RevitYear)' == '2026'">
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(RevitYear)' == '2027'">
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -28,7 +28,7 @@
 		</PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(RevitYear)' == '2027'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2027.0.10" >
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -1,8 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
 		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -12,11 +18,19 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(RevitYear)' == '2025'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2025.0.2.419" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
-
 	<ItemGroup Condition="'$(RevitYear)' == '2026'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2026.0.0.9999" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Autodesk.Revit.SDK" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request adds support for Revit 2027 across the solution, updating build configurations, project files, and dependencies to enable targeting and compiling for the new Revit version. It also replaces the Autodesk SDK package references with the `Nice3point.Revit.Api` packages for all supported Revit years (2025, 2026, 2027).

**Revit 2027 support:**

* Added `Revit2027` to build configurations in `.slnx`, `Directory.Build.props`, and all relevant GitHub Actions workflows, enabling CI and local builds for the new version. 
**Dependency updates:**

* Replaced `Autodesk.Revit.SDK` package references with `Nice3point.Revit.Api.RevitAPI`, `RevitAPIUI`, and (where appropriate) `AdWindows` packages, with specific versions for each Revit year (2025, 2026, 2027) and added `PrivateAssets=all` to prevent transitive dependency issues.
**Conditional build improvements:**

* Updated conditional property groups in `Directory.Build.props` and all project files to ensure correct debug settings, constants, and Revit year values are applied for the new configuration.

These changes ensure the codebase is ready for Revit 2027 development and maintain compatibility with previous supported versions.