### PR TITLE
Enhance prerelease package unlisting and add Revit 2027 support

### DIFF
--- a/.github/agents/xml-doc-creator.agent.md
+++ b/.github/agents/xml-doc-creator.agent.md
@@ -1,0 +1,150 @@
+---
+name: xml-doc-creator
+description: Creates and improves XML documentation comments for C# classes, interfaces, methods, properties, events, fields, records, and enums.
+---
+
+# XML Documentation Creator
+
+You are a C# documentation specialist.
+
+Your task is to create high-quality XML documentation comments for C# source code.
+
+## Goals
+
+- Add missing XML documentation comments.
+- Improve existing XML documentation comments when they are incomplete, misleading, or unclear.
+- Preserve the original code behavior.
+- Do not change method signatures, access modifiers, namespaces, attributes, or implementation logic.
+- Keep documentation concise, precise, and useful for IntelliSense and generated API documentation.
+
+## Documentation Rules
+
+Use standard C# XML documentation comments:
+
+```xml
+/// <summary>
+/// ...
+/// </summary>
+```
+
+Add documentation for:
+
+- Classes
+- Interfaces
+- Structs
+- Records
+- Enums
+- Constructors
+- Methods
+- Properties
+- Indexers
+- Events
+- Delegates
+- Public constants and fields
+
+Prefer documenting public and protected APIs first.  
+Document private members only when explicitly requested.
+
+## Required XML Tags
+
+Use the following tags where appropriate:
+
+- <summary> for all documented members.
+- <param name="..."> for each method, constructor, delegate, or indexer parameter.
+- <typeparam name="..."> for each generic type parameter.
+- <returns> for methods that return a value.
+- <exception cref="..."> only when the code clearly throws or documents that exception.
+- <value> for properties only when it adds information beyond the summary.
+- <remarks> only for important behavioral details, constraints, lifecycle notes, threading, performance, or API usage.
+- <inheritdoc /> when overriding, implementing, or forwarding documentation is clearly appropriate.
+
+## Style Guidelines
+
+- Write in clear technical English.
+- Use third-person descriptive style.
+- Start summaries with a verb phrase where possible, for example:
+  - “Gets the current value.”
+  - “Creates a new instance of the class.”
+  - “Loads the configuration from the specified path.”
+- Do not repeat the member name unless it improves clarity.
+- Avoid vague summaries such as “Gets or sets the value.”
+- Avoid documenting implementation details unless they affect API usage.
+- Avoid marketing language.
+- Keep comments short unless the API requires explanation.
+- Use line breaks for long text. The maximal line length is 120 characters, but shorter lines are preferred for readability.
+
+## C# XML Reference Rules
+
+Use XML documentation references where helpful:
+
+- Use <see cref="TypeName" /> for related types, members, exceptions, and constants.
+- Use <paramref name="parameterName" /> when referring to parameters.
+- Use <typeparamref name="T" /> when referring to generic type parameters.
+- Use <c>...</c> for inline code, literals, keywords, and enum values.
+- Use <code>...</code> only for short examples or multi-line code snippets.
+
+## Nullability and Behavior
+
+When inferable from the code:
+
+- Mention whether parameters may be `null`.
+- Mention whether return values may be `null`.
+- Mention ownership or disposal requirements.
+- Mention whether collections are modified, copied, cached, or returned directly.
+- Mention async behavior, cancellation tokens, and task results.
+- Mention side effects such as file access, network access, logging, database access, or mutation.
+
+Do not invent behavior that is not visible from the code.
+
+## Exceptions
+
+Only document exceptions that are clearly thrown by the code or explicitly part of the contract.
+
+Good:
+
+```xml
+/// <exception cref="ArgumentNullException">
+/// Thrown when <paramref name="path" /> is <see langword="null" />.
+/// </exception>
+```
+
+Bad:
+
+```xml
+/// <exception cref="Exception">
+/// Thrown when an error occurs.
+/// </exception>
+```
+
+## Formatting
+
+- Preserve the existing formatting style.
+- Place XML documentation immediately above the member.
+- Do not add empty XML tags.
+- Do not add trailing whitespace.
+- Keep line length reasonable.
+- Use valid XML; escape special characters such as `&`, `<`, and `>`.
+
+## Output Rules
+
+When editing code:
+
+- Return the updated code only.
+- Do not explain the changes unless explicitly asked.
+- Do not wrap the result in Markdown unless explicitly asked.
+- Do not modify unrelated code.
+- Do not reformat the whole file unless required.
+
+When reviewing documentation:
+
+- Point out inaccurate, redundant, or missing documentation.
+- Suggest concrete replacements.
+- Prefer actionable comments over general advice.
+
+## Important Constraints
+
+- Never change code behavior.
+- Never invent undocumented side effects.
+- Never document exceptions that are only theoretically possible.
+- Never remove meaningful existing documentation unless replacing it with a clearer version.
+- Never add comments that simply restate the obvious.

--- a/.github/workflows/Build & Deploy.yml
+++ b/.github/workflows/Build & Deploy.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        revitYear: [2025, 2026]
+        revitYear: [2025, 2026, 2027]
 
     steps:
     - name: Checkout

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        revitYear: [2025, 2026]
+        revitYear: [2025, 2026, 2027]
 
     steps:
     - name: Checkout

--- a/.github/workflows/HidePrereleasePackages.yml
+++ b/.github/workflows/HidePrereleasePackages.yml
@@ -3,13 +3,13 @@ name: Unlist NuGet prerelease versions
 on:
   workflow_dispatch:
     inputs:
-      package_id:
-        description: 'NuGet package ID'
+      package_pattern:
+        description: 'NuGet package ID or wildcard pattern'
         required: true
         type: string
-        default: 'Your.Package.Id'
+        default: 'scotec.revit.*'
       keep_latest:
-        description: 'Keep latest prerelease version'
+        description: 'Keep latest prerelease version per package'
         required: true
         type: boolean
         default: true
@@ -19,40 +19,124 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Unlist prerelease versions
+      - name: Unlist listed prerelease versions
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-          PACKAGE_ID: ${{ github.event.inputs.package_id }}
+          PACKAGE_PATTERN: ${{ github.event.inputs.package_pattern }}
           KEEP_LATEST: ${{ github.event.inputs.keep_latest }}
         run: |
           $source = "https://api.nuget.org/v3/index.json"
-          $packageId = $env:PACKAGE_ID
-          $packageIdLower = $packageId.ToLowerInvariant()
-          $versionsUrl = "https://api.nuget.org/v3-flatcontainer/$packageIdLower/index.json"
+          $pattern = $env:PACKAGE_PATTERN.Trim()
 
-          $versions = (Invoke-RestMethod -Uri $versionsUrl).versions
+          if ([string]::IsNullOrWhiteSpace($pattern)) {
+            throw "Package pattern is empty."
+          }
 
-          $preReleaseVersions = $versions |
-            Where-Object { $_ -like "*-*" }
-
-          if ($env:KEEP_LATEST -eq "true") {
-            $versionsToUnlist = $preReleaseVersions | Select-Object -SkipLast 1
+          if ($pattern.EndsWith(".*")) {
+            $prefix = $pattern.Substring(0, $pattern.Length - 2)
+            $packageRegex = "^" + [regex]::Escape($prefix) + "(\..+)?$"
+            $searchTerm = $prefix
           }
           else {
-            $versionsToUnlist = $preReleaseVersions
+            $packageRegex = "^" + [regex]::Escape($pattern).Replace("\*", ".*") + "$"
+            $searchTerm = $pattern.Replace("*", "")
           }
 
-          if (-not $versionsToUnlist) {
-            Write-Host "No prerelease versions to unlist."
+          $encodedSearchTerm = [System.Uri]::EscapeDataString($searchTerm)
+          $searchUrl = "https://azuresearch-usnc.nuget.org/query?q=$encodedSearchTerm&take=1000"
+
+          Write-Host "Searching packages from $searchUrl"
+
+          $searchResult = Invoke-RestMethod -Uri $searchUrl -ErrorAction Stop
+
+          $packageIds = @(
+            $searchResult.data |
+              Where-Object { $_.id -match $packageRegex } |
+              ForEach-Object { $_.id } |
+              Sort-Object -Unique
+          )
+
+          if ($packageIds.Count -eq 0) {
+            Write-Host "No packages matched pattern '$pattern'."
             exit 0
           }
 
-          foreach ($version in $versionsToUnlist) {
-            Write-Host "Unlisting $packageId $version"
+          Write-Host "Matched packages:"
+          $packageIds | ForEach-Object { Write-Host " - $_" }
 
-            dotnet nuget delete $packageId $version `
-              --source $source `
-              --api-key $env:NUGET_API_KEY `
-              --non-interactive
+          foreach ($packageId in $packageIds) {
+            Write-Host ""
+            Write-Host "Processing package: $packageId"
+
+            $packageIdLower = $packageId.ToLowerInvariant()
+            $registrationUrl = "https://api.nuget.org/v3/registration5-gz-semver2/$packageIdLower/index.json"
+
+            $registration = Invoke-RestMethod -Uri $registrationUrl -ErrorAction Stop
+
+            $entries = New-Object System.Collections.Generic.List[object]
+
+            foreach ($page in $registration.items) {
+              if ($null -ne $page.items) {
+                foreach ($item in $page.items) {
+                  $entries.Add($item)
+                }
+              }
+              else {
+                $pageData = Invoke-RestMethod -Uri $page.'@id' -ErrorAction Stop
+                foreach ($item in $pageData.items) {
+                  $entries.Add($item)
+                }
+              }
+            }
+
+            $listedPreReleaseVersions = New-Object System.Collections.Generic.List[string]
+
+            foreach ($entry in $entries) {
+              $catalogEntry = $entry.catalogEntry
+              if ($null -eq $catalogEntry) {
+                continue
+              }
+
+              $version = [string]$catalogEntry.version
+              if ([string]::IsNullOrWhiteSpace($version)) {
+                continue
+              }
+
+              $listedProperty = $catalogEntry.PSObject.Properties["listed"]
+              $isListed = ($null -eq $listedProperty) -or ([bool]$catalogEntry.listed)
+
+              if ($version.Contains("-") -and $isListed) {
+                $listedPreReleaseVersions.Add($version)
+              }
+            }
+
+            if ($listedPreReleaseVersions.Count -eq 0) {
+              Write-Host "No listed prerelease versions found for $packageId."
+              continue
+            }
+
+            if ($env:KEEP_LATEST -eq "true") {
+              $versionsToUnlist = @($listedPreReleaseVersions | Select-Object -SkipLast 1)
+            }
+            else {
+              $versionsToUnlist = @($listedPreReleaseVersions)
+            }
+
+            if ($versionsToUnlist.Count -eq 0) {
+              Write-Host "No prerelease versions to unlist for $packageId."
+              continue
+            }
+
+            Write-Host "Versions to unlist for ${packageId}:"
+            $versionsToUnlist | ForEach-Object { Write-Host " - $_" }
+
+            foreach ($version in $versionsToUnlist) {
+              Write-Host "Unlisting $packageId $version"
+
+              dotnet nuget delete $packageId $version `
+                --source $source `
+                --api-key $env:NUGET_API_KEY `
+                --non-interactive
+            }
           }

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 2026.3.0
+next-version: 2027.3.2
 branches: 
     main:
         increment: Patch

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -10,10 +10,10 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Configurations>Release;Revit2025;Revit2026</Configurations>
+		<Configurations>Release;Revit2025;Revit2026;Revit2027</Configurations>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)' == 'Revit2025' Or '$(Configuration)' == 'Revit2026'">
+	<PropertyGroup Condition="'$(Configuration)' == 'Revit2025' Or '$(Configuration)' == 'Revit2026' Or '$(Configuration)' == 'Revit2027'">
 		<DebugSymbols>true</DebugSymbols>
 		<DebugType>portable</DebugType>
 		<Optimize>false</Optimize>
@@ -25,10 +25,13 @@
 		<RevitYear>2025</RevitYear>
 		<DefineConstants>$(DefineConstants);REVIT2025</DefineConstants>
 	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(Configuration)' == 'Revit2026'">
 		<RevitYear>2026</RevitYear>
 		<DefineConstants>$(DefineConstants);REVIT2026</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)' == 'Revit2027'">
+		<RevitYear>2027</RevitYear>
+		<DefineConstants>$(DefineConstants);REVIT2027</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(RevitYear)' == ''">

--- a/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
+++ b/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
@@ -1,11 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
 		<TargetFramework>net8.0-windows</TargetFramework>
-		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-
 	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
+
+	<!--<PropertyGroup>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	</PropertyGroup>-->
 
 	<PropertyGroup>
 		<Description>Support for Revit add-in isolation.</Description>
@@ -32,13 +39,29 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(RevitYear)' == '2025'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2025.0.2.419" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
-
 	<ItemGroup Condition="'$(RevitYear)' == '2026'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2026.0.0.9999" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
-
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 	<!--Not working that way.-->
 	<!--<Target Name="PackSourceGenerator" BeforeTargets="Pack">
 		--><!-- Build generator (safe even if already built; MSBuild will incremental-skip) --><!--

--- a/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
+++ b/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
@@ -1,8 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
 		<UseWpf>True</UseWpf>
 	</PropertyGroup>
 
@@ -36,6 +44,41 @@
 		<None Include="DynamicCommands\RevitDynamicActionCommandFactory.cs" />
 		<None Include="DynamicCommands\RevitDynamicCommandFactory.cs" />
 	</ItemGroup>
+
+	<ItemGroup Condition="'$(RevitYear)' == '2025'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.AdWindows" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2026'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.AdWindows" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.AdWindows" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />

--- a/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
+++ b/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
@@ -1,9 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
 		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
+	</PropertyGroup>
+
+	<PropertyGroup>
 		<UseWpf>True</UseWpf>
 	</PropertyGroup>
+
+	<ItemGroup Condition="'$(RevitYear)' == '2025'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2026'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
 
 	<ItemGroup>
 		<ProjectReference Include="..\Scotec.Revit.Isolation\Scotec.Revit.Isolation.csproj" />

--- a/Source/Scotec.Revit.slnx
+++ b/Source/Scotec.Revit.slnx
@@ -3,6 +3,7 @@
     <BuildType Name="Release" />
     <BuildType Name="Revit2025" />
     <BuildType Name="Revit2026" />
+    <BuildType Name="Revit2027" />
     <Platform Name="x64" />
   </Configurations>
   <Folder Name="/SolutionItems/">

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -1,8 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
 		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
+		<TargetFramework>net8.0-windows</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
+		<TargetFramework>net10.0-windows</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -12,11 +18,28 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(RevitYear)' == '2025'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2025.0.2.419" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2025.4.41" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
-
 	<ItemGroup Condition="'$(RevitYear)' == '2026'">
-		<PackageReference Include="Autodesk.Revit.SDK" Version="2026.0.0.9999" />
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2026.4.0" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(RevitYear)' == '2027'">
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="2027.0.10" >
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This pull request adds support for Revit 2027 across the codebase, updates NuGet dependencies to use the `Nice3point.Revit.Api` packages for all supported Revit versions, and improves the automation for managing prerelease NuGet packages. It also introduces a new agent for generating high-quality XML documentation comments for C# code.

**Revit 2027 Support**

* Added `Revit2027` build configuration to solution/project files and CI workflows, including conditional target frameworks and constants for Revit 2027. (`Source/Directory.Build.props`, `Source/Scotec.Revit.slnx`, `Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj`, `Source/Scotec.Revit/Scotec.Revit.csproj`, `Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj`, `Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj`, `.github/workflows/Build.yml`, `.github/workflows/Build & Deploy.yml`

* For Revit 2027, projects now target `net10.0-windows` and reference the appropriate versions of `Nice3point.Revit.Api` packages. (`Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj`, `Source/Scotec.Revit/Scotec.Revit.csproj`, `Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj`, `Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj`,

**NuGet Dependency Updates**

* Replaced `Autodesk.Revit.SDK` package references with `Nice3point.Revit.Api.RevitAPI` and `Nice3point.Revit.Api.RevitAPIUI` for all supported Revit versions, and added `Nice3point.Revit.Api.AdWindows` for UI projects. (`Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj`, `Source/Scotec.Revit/Scotec.Revit.csproj`, `Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj`, `Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj`

**Continuous Integration and Versioning**

* Updated GitHub Actions workflows to include Revit 2027 in the build matrix. (`.github/workflows/Build.yml`, `.github/workflows/Build & Deploy.yml`

**NuGet Prerelease Management Improvements**

* Enhanced the `HidePrereleasePackages.yml` workflow to support unlisting prerelease versions for multiple packages using wildcard patterns, improved logic for finding and unlisting only listed prerelease versions, and made the process more robust. (`.github/workflows/HidePrereleasePackages.yml`

**Documentation Automation**

* Added a new agent definition for `xml-doc-creator`, which provides detailed instructions and rules for generating and improving C# XML documentation comments. (`.github/agents/xml-doc-creator.agent.md`