### PR TITLE
Enable multi-targeting for Revit projects across .NET versions

### DIFF
--- a/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
+++ b/Source/Scotec.Revit.Isolation/Scotec.Revit.Isolation.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFrameworks>net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<!--<PropertyGroup>

--- a/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
+++ b/Source/Scotec.Revit.Ui/Scotec.Revit.Ui.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFrameworks>net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
+++ b/Source/Scotec.Revit.Wpf/Scotec.Revit.Wpf.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFrameworks>net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -2,13 +2,13 @@
 
 
 	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2026'">
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFrameworks>net8.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RevitYear)' == '2027'">
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFrameworks>net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
This pull request updates the project files for several Revit-related components to support multiple target frameworks for different Revit versions. The main change is that, for Revit 2025 and 2026, the projects will now build against both .NET 8.0 and .NET 10.0, improving compatibility and future-proofing the codebase.

Multi-targeting enhancements:

* Updated `Scotec.Revit.Isolation.csproj`, `Scotec.Revit.Ui.csproj`, `Scotec.Revit.Wpf.csproj`, and `Scotec.Revit.csproj` so that for Revit 2025 and 2026, the projects target both `net8.0-windows` and `net10.0-windows` instead of just `net8.0-windows`. For Revit 2027, targeting remains `net10.0-windows` only.  Switch to <TargetFrameworks> for all Revit year configs. Revit 2025 and 2026 now target both net8.0-windows and net10.0-windows; Revit 2027 targets net10.0-windows only. This improves compatibility across .NET versions.