### PR TITLE
Add DI-aware RevitTask overloads, RevitBasicFileInfo, and multi-targeting for .NET 10

### DIFF
--- a/Source/Scotec.Revit/RevitFamily/RevitBasicFileInfo.cs
+++ b/Source/Scotec.Revit/RevitFamily/RevitBasicFileInfo.cs
@@ -1,0 +1,473 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace Scotec.Revit.RevitFamily;
+
+public sealed class RevitBasicFileInfo
+{
+    private static readonly Dictionary<string, string[]> PropertyKeys = new(StringComparer.Ordinal)
+    {
+        [nameof(IsForeign)] = ["IsForeign", "Foreign"],
+        [nameof(ClientAppName)] = ["ClientAppName", "Client App Name"],
+        [nameof(Author)] = ["Author"],
+        [nameof(ModelIdentity)] = ["ModelIdentity", "Unique Document GUID"],
+        [nameof(LatestCentralEpisodeGUID)] =
+        [
+            "LatestCentralEpisodeGUID",
+            "LatestCentralEpisodeGuid",
+            "Central model's episode GUID corresponding to the last reload latest"
+        ],
+        [nameof(LatestCentralVersion)] =
+        [
+            "LatestCentralVersion",
+            "Central model's version number corresponding to the last reload latest"
+        ],
+        [nameof(AllLocalChangesSavedToCentral)] =
+        [
+            "AllLocalChangesSavedToCentral",
+            "All local changes saved to central"
+        ],
+        [nameof(CentralPath)] = ["CentralPath", "Central Path"],
+        [nameof(Username)] = ["Username"],
+        [nameof(LanguageWhenSaved)] = ["LanguageWhenSaved", "Language When Saved"],
+        [nameof(Format)] = ["Format"],
+        [nameof(IsSavedInLaterVersion)] = ["IsSavedInLaterVersion", "SavedInLaterVersion"],
+        [nameof(IsSavedInCurrentVersion)] = ["IsSavedInCurrentVersion", "SavedInCurrentVersion"],
+        [nameof(IsCreatedLocal)] = ["IsCreatedLocal", "CreatedLocal"],
+        [nameof(IsInProgress)] = ["IsInProgress", "InProgress"],
+        [nameof(IsCentral)] = ["IsCentral", "Central"],
+        [nameof(IsLocal)] = ["IsLocal", "Local"],
+        [nameof(IsWorkshared)] = ["IsWorkshared", "Worksharing"]
+    };
+
+    private readonly Dictionary<string, string> _values;
+
+    private RevitBasicFileInfo(Dictionary<string, string> values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    ///     All parsed key/value pairs.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Values => _values;
+
+    /// <summary>
+    ///     Gets a value indicating whether the file was saved by a non-Autodesk application.
+    /// </summary>
+    public bool IsForeign => GetBool(nameof(IsForeign));
+
+    /// <summary>
+    ///     Gets the client application name.
+    /// </summary>
+    public string? ClientAppName => GetPropertyValue(nameof(ClientAppName));
+
+    /// <summary>
+    ///     Gets the author of the file.
+    /// </summary>
+    public string? Author => GetPropertyValue(nameof(Author));
+
+    /// <summary>
+    ///     Gets the GUID that identifies the model.
+    /// </summary>
+    public Guid? ModelIdentity => GetGuid(nameof(ModelIdentity));
+
+    /// <summary>
+    ///     Gets the central model episode GUID corresponding to the last reload latest.
+    /// </summary>
+    public Guid? LatestCentralEpisodeGUID => GetGuid(nameof(LatestCentralEpisodeGUID));
+
+    /// <summary>
+    ///     Gets the central model version corresponding to the last reload latest.
+    /// </summary>
+    public int? LatestCentralVersion => GetInt(nameof(LatestCentralVersion));
+
+    /// <summary>
+    ///     Gets a value indicating whether all local changes are saved to central.
+    /// </summary>
+    public bool AllLocalChangesSavedToCentral => GetBool(nameof(AllLocalChangesSavedToCentral));
+
+    /// <summary>
+    ///     Gets the central model path.
+    /// </summary>
+    public string? CentralPath => GetPropertyValue(nameof(CentralPath));
+
+    /// <summary>
+    ///     Gets the username stored in the file information.
+    /// </summary>
+    public string? Username => GetPropertyValue(nameof(Username));
+
+    /// <summary>
+    ///     Gets the language active when the file was last saved.
+    /// </summary>
+    public string? LanguageWhenSaved => GetPropertyValue(nameof(LanguageWhenSaved));
+
+    /// <summary>
+    ///     Gets the file format indicator.
+    /// </summary>
+    public string? Format => GetPropertyValue(nameof(Format));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file was saved in a later Revit version.
+    /// </summary>
+    public bool IsSavedInLaterVersion => GetBool(nameof(IsSavedInLaterVersion));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file was saved in the current Revit version.
+    /// </summary>
+    public bool IsSavedInCurrentVersion => GetBool(nameof(IsSavedInCurrentVersion));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file is a created local file.
+    /// </summary>
+    public bool IsCreatedLocal => GetBool(nameof(IsCreatedLocal));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file is in progress of becoming central.
+    /// </summary>
+    public bool IsInProgress => GetBool(nameof(IsInProgress));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file is the central model.
+    /// </summary>
+    public bool IsCentral => GetBool(nameof(IsCentral));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file is a local model.
+    /// </summary>
+    public bool IsLocal => GetBool(nameof(IsLocal));
+
+    /// <summary>
+    ///     Gets a value indicating whether the file is workshared.
+    /// </summary>
+    public bool IsWorkshared => GetBool(nameof(IsWorkshared));
+
+    /// <summary>
+    ///     Parses a Revit BasicFileInfo stream.
+    /// </summary>
+    public static RevitBasicFileInfo Parse(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        using var memory = new MemoryStream();
+        stream.CopyTo(memory);
+
+        return Parse(memory.ToArray());
+    }
+
+    /// <summary>
+    ///     Parses raw BasicFileInfo bytes.
+    /// </summary>
+    public static RevitBasicFileInfo Parse(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        var text = Decode(bytes);
+
+        var values = ParseValues(text);
+
+        return new RevitBasicFileInfo(values);
+    }
+
+    /// <summary>
+    ///     Creates a <see cref="RevitBasicFileInfo" /> instance from a BasicFileInfo stream.
+    /// </summary>
+    public static RevitBasicFileInfo FromStream(Stream stream)
+    {
+        return Parse(stream);
+    }
+
+    /// <summary>
+    ///     Creates a <see cref="RevitBasicFileInfo" /> instance from raw BasicFileInfo bytes.
+    /// </summary>
+    public static RevitBasicFileInfo FromBytes(byte[] bytes)
+    {
+        return Parse(bytes);
+    }
+
+    /// <summary>
+    ///     Gets a raw value by key.
+    /// </summary>
+    public string? GetValue(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        return _values.TryGetValue(key, out var value)
+            ? value
+            : null;
+    }
+
+    /// <summary>
+    ///     Gets a value using the known aliases of a <see cref="Autodesk.Revit.DB.BasicFileInfo" /> property.
+    /// </summary>
+    public string? GetPropertyValue(string propertyName)
+    {
+        ArgumentNullException.ThrowIfNull(propertyName);
+
+        if (PropertyKeys.TryGetValue(propertyName, out var keys))
+        {
+            foreach (var key in keys)
+            {
+                if (_values.TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+            }
+        }
+
+        return GetValue(propertyName);
+    }
+
+    /// <summary>
+    ///     Gets a GUID value by property name.
+    /// </summary>
+    public Guid? GetGuid(string propertyName)
+    {
+        var value = GetPropertyValue(propertyName);
+
+        return Guid.TryParse(value, out var guid)
+            ? guid
+            : null;
+    }
+
+    /// <summary>
+    ///     Gets an integer value by property name.
+    /// </summary>
+    public int? GetInt(string propertyName)
+    {
+        var value = GetPropertyValue(propertyName);
+
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number)
+            ? number
+            : null;
+    }
+
+    private bool GetBool(string propertyName)
+    {
+        return TryGetBool(propertyName, out var value) && value;
+    }
+
+    private bool TryGetBool(string propertyName, out bool value)
+    {
+        value = false;
+
+        var text = GetPropertyValue(propertyName);
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return bool.TryParse(text, out value);
+    }
+
+    private static Dictionary<string, string> ParseValues(string text)
+    {
+        var result = new Dictionary<string, string>(
+            StringComparer.OrdinalIgnoreCase);
+
+        using var reader = new StringReader(text);
+
+        while (reader.ReadLine() is { } line)
+        {
+            line = line.Trim();
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var index = line.IndexOf(':');
+
+            if (index <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..index].Trim();
+            var value = line[(index + 1)..].Trim();
+
+            result[key] = value;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///     Decodes the mixed UTF16/ASCII encoding used inside Revit BasicFileInfo streams.
+    /// </summary>
+    private static string Decode(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        var candidates = new[]
+        {
+            DecodeMixedAscii(bytes),
+            Encoding.Unicode.GetString(bytes),
+            Encoding.BigEndianUnicode.GetString(bytes),
+            Encoding.UTF8.GetString(bytes),
+            Encoding.ASCII.GetString(bytes)
+        };
+
+        string? bestText = null;
+        var bestScore = int.MinValue;
+
+        foreach (var candidate in candidates)
+        {
+            var normalized = NormalizeWhitespace(candidate);
+            var score = Score(normalized);
+            if (score > bestScore)
+            {
+                bestScore = score;
+                bestText = normalized;
+            }
+        }
+
+        return bestText ?? string.Empty;
+    }
+
+    private static string DecodeMixedAscii(byte[] bytes)
+    {
+        var sb = new StringBuilder(bytes.Length);
+
+        for (var i = 0; i < bytes.Length;)
+        {
+            var b0 = bytes[i];
+            var b1 = i + 1 < bytes.Length
+                ? bytes[i + 1]
+                : (byte)0;
+
+            // UTF16-LE ASCII
+            // Example: 57 00 6F 00 ...
+            if (IsTextByte(b0) && b1 == 0x00)
+            {
+                AppendDecodedChar(sb, b0);
+                i += 2;
+                continue;
+            }
+
+            // UTF16-BE ASCII
+            // Example: 00 57 00 6F ...
+            if (b0 == 0x00 && IsTextByte(b1))
+            {
+                AppendDecodedChar(sb, b1);
+                i += 2;
+                continue;
+            }
+
+            // Plain ASCII
+            if (IsTextByte(b0))
+            {
+                AppendDecodedChar(sb, b0);
+            }
+            else
+            {
+                sb.Append(' ');
+            }
+
+            i++;
+        }
+
+        return NormalizeWhitespace(sb.ToString());
+    }
+
+    private static bool IsTextByte(byte value)
+    {
+        return value is >= 0x20 and <= 0x7E or (byte)'\r' or (byte)'\n' or (byte)'\t';
+    }
+
+    private static void AppendDecodedChar(StringBuilder builder, byte value)
+    {
+        builder.Append((char)value);
+    }
+
+    private static int Score(string text)
+    {
+        var score = 0;
+
+        foreach (var keys in PropertyKeys.Values)
+        {
+            foreach (var key in keys)
+            {
+                if (text.IndexOf(key, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    score += 10;
+                    break;
+                }
+            }
+        }
+
+        foreach (var c in text)
+        {
+            if (c == ':')
+            {
+                score++;
+            }
+            else if (c == '\n')
+            {
+                score += 2;
+            }
+        }
+
+        return score;
+    }
+
+    private static string NormalizeWhitespace(string text)
+    {
+        using var reader = new StringReader(text);
+        var sb = new StringBuilder(text.Length);
+
+        var isFirstLine = true;
+
+        while (reader.ReadLine() is { } line)
+        {
+            var normalizedLine = NormalizeLine(line);
+
+            if (normalizedLine.Length == 0)
+            {
+                continue;
+            }
+
+            if (!isFirstLine)
+            {
+                sb.AppendLine();
+            }
+
+            sb.Append(normalizedLine);
+            isFirstLine = false;
+        }
+
+        return sb.ToString();
+    }
+
+    private static string NormalizeLine(string text)
+    {
+        var sb = new StringBuilder(text.Length);
+
+        var previousWhitespace = false;
+
+        foreach (var c in text)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                if (!previousWhitespace)
+                {
+                    sb.Append(' ');
+                    previousWhitespace = true;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+                previousWhitespace = false;
+            }
+        }
+
+        return sb.ToString()
+            .Trim()
+            .Replace(" :", ":", StringComparison.Ordinal);
+    }
+}

--- a/Source/Scotec.Revit/RevitTask.cs
+++ b/Source/Scotec.Revit/RevitTask.cs
@@ -3,9 +3,14 @@
 // This file is licensed to you under the MIT license.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Scotec.Revit;
 
@@ -36,6 +41,19 @@ public sealed class RevitTask : IExternalEventHandler, IDisposable
     {
         _name = name ?? string.Empty;
         _externalEvent = ExternalEvent.Create(this);
+    }
+
+    /// <summary>
+    ///     Releases all resources used by the <see cref="RevitTask" /> instance.
+    /// </summary>
+    /// <remarks>
+    ///     This method disposes of the external event and reset event associated with the <see cref="RevitTask" /> instance.
+    ///     It should be called when the task is no longer needed to free up resources.
+    /// </remarks>
+    public void Dispose()
+    {
+        _externalEvent.Dispose();
+        _resetEvent.Dispose();
     }
 
     /// <summary>
@@ -139,6 +157,133 @@ public sealed class RevitTask : IExternalEventHandler, IDisposable
     }
 
     /// <summary>
+    ///     Executes a task within the Revit API context using a delegate whose parameters are resolved
+    ///     from a scoped Autofac lifetime scope, and returns a result of the specified type.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the delegate.</typeparam>
+    /// <param name="action">
+    ///     A delegate with any number and types of parameters. All parameters are resolved from the
+    ///     scoped service provider. The scope automatically registers the current
+    ///     <see cref="Autodesk.Revit.UI.UIApplication" />, <see cref="Autodesk.Revit.ApplicationServices.Application" />,
+    ///     <see cref="Autodesk.Revit.UI.UIDocument" /> (if available), <see cref="Autodesk.Revit.DB.Document" /> (if available),
+    ///     and the active <see cref="Autodesk.Revit.DB.View" /> (if available).
+    /// </param>
+    /// <param name="configureServices">
+    ///     An optional callback to register additional services into the lifetime scope before
+    ///     the delegate is invoked.
+    /// </param>
+    /// <returns>A <see cref="Task{TResult}" /> containing the delegate's return value.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="action" /> is <c>null</c>.</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown if a required service cannot be resolved from the container.</exception>
+    public async Task<TResult> Run<TResult>(Delegate action, Action<IServiceCollection>? configureServices = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        _action = uiApplication =>
+        {
+            using var scope = CreateLifetimeScope(uiApplication, configureServices);
+            var serviceProvider = scope.Resolve<IServiceProvider>();
+            var args = action.Method.GetParameters()
+                             .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
+                             .ToArray();
+
+            return action.DynamicInvoke(args)!;
+        };
+
+        return (TResult)await ExecuteInternalAsync<object>();
+    }
+
+    /// <summary>
+    ///     Executes a task within the Revit API context using a delegate whose parameters are resolved
+    ///     from a scoped Autofac lifetime scope.
+    /// </summary>
+    /// <param name="action">
+    ///     A delegate with any number and types of parameters. All parameters are resolved from the
+    ///     scoped service provider. The scope automatically registers the current
+    ///     <see cref="Autodesk.Revit.UI.UIApplication" />, <see cref="Autodesk.Revit.ApplicationServices.Application" />,
+    ///     <see cref="Autodesk.Revit.UI.UIDocument" /> (if available), <see cref="Autodesk.Revit.DB.Document" /> (if available),
+    ///     and the active <see cref="Autodesk.Revit.DB.View" /> (if available).
+    /// </param>
+    /// <param name="configureServices">
+    ///     An optional callback to register additional services into the lifetime scope before
+    ///     the delegate is invoked.
+    /// </param>
+    /// <returns>A <see cref="Task" /> representing the asynchronous operation.</returns>
+    /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="action" /> is <c>null</c>.</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown if a required service cannot be resolved from the container.</exception>
+    public async Task Run(Delegate action, Action<IServiceCollection>? configureServices = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        _action = uiApplication =>
+        {
+            using var scope = CreateLifetimeScope(uiApplication, configureServices);
+            var serviceProvider = scope.Resolve<IServiceProvider>();
+
+            var args = action.Method.GetParameters()
+                             .Select(p => serviceProvider.GetRequiredService(p.ParameterType))
+                             .ToArray();
+
+            action.DynamicInvoke(args);
+            return new object();
+        };
+
+        await ExecuteInternalAsync<object>();
+    }
+
+    /// <summary>
+    ///     Creates a scoped Autofac lifetime scope for use within a Revit API context.
+    ///     The scope automatically registers the current <see cref="Autodesk.Revit.UI.UIApplication" />,
+    ///     <see cref="Autodesk.Revit.ApplicationServices.Application" />,
+    ///     <see cref="Autodesk.Revit.UI.UIDocument" /> (if available),
+    ///     <see cref="Autodesk.Revit.DB.Document" /> (if available),
+    ///     and the active <see cref="Autodesk.Revit.DB.View" /> (if available).
+    /// </summary>
+    /// <param name="uiApplication">
+    ///     The current <see cref="Autodesk.Revit.UI.UIApplication" /> instance providing access to
+    ///     the Revit application and its active document context.
+    /// </param>
+    /// <param name="configureServices">
+    ///     An optional callback to register additional services into the lifetime scope before
+    ///     the scope is returned.
+    /// </param>
+    /// <returns>
+    ///     A new <see cref="ILifetimeScope" /> with Revit context services registered.
+    /// </returns>
+    private static ILifetimeScope CreateLifetimeScope(UIApplication uiApplication, Action<IServiceCollection>? configureServices)
+    {
+        var uiDocument = uiApplication.ActiveUIDocument;
+        var document = uiDocument?.Document;
+        var view = uiDocument?.ActiveView;
+        return RevitAppBase.GetServiceProvider(uiApplication.Application.ActiveAddInId.GetGUID())
+                           .GetAutofacRoot()
+                           .BeginLifetimeScope(builder =>
+                           {
+                               if (uiDocument is not null)
+                               {
+                                   builder.RegisterInstance(uiDocument).ExternallyOwned();
+                               }
+
+                               if (document is not null)
+                               {
+                                   builder.RegisterInstance(document).ExternallyOwned();
+                               }
+
+                               if (view is not null)
+                               {
+                                   builder.RegisterInstance(view).ExternallyOwned();
+                               }
+
+                               builder.RegisterInstance(uiApplication.Application).ExternallyOwned();
+
+                               // Allow to add services
+                               var services = new ServiceCollection();
+                               configureServices?.Invoke(services);
+                               builder.Populate(services);
+                           });
+    }
+
+    /// <summary>
     ///     Executes the internal logic of the task within the Revit API context and returns a result of the specified type.
     /// </summary>
     /// <typeparam name="TResult">
@@ -165,17 +310,5 @@ public sealed class RevitTask : IExternalEventHandler, IDisposable
         });
         return task;
     }
-
-    /// <summary>
-    /// Releases all resources used by the <see cref="RevitTask"/> instance.
-    /// </summary>
-    /// <remarks>
-    /// This method disposes of the external event and reset event associated with the <see cref="RevitTask"/> instance.
-    /// It should be called when the task is no longer needed to free up resources.
-    /// </remarks>
-    public void Dispose()
-    {
-        _externalEvent.Dispose();
-        _resetEvent.Dispose();
-    }
 }
+


### PR DESCRIPTION
## Summary

This PR introduces DI-aware `RevitTask.Run` overloads, a new `RevitBasicFileInfo`
class, and updates all Revit projects to multi-target .NET 8 and .NET 10.

## Changes

### `RevitTask` – DI-aware `Run` overloads
Two new `Run` overloads accept a `Delegate` with any number and types of parameters.
At execution time, a scoped Autofac lifetime scope is created and each delegate
parameter is resolved from it. The scope automatically registers the following
Revit context objects (where available):

- `UIApplication` / `Application`
- `UIDocument` / `Document`
- Active `View`

An optional `Action<IServiceCollection>` callback allows callers to register
additional services into the scope before invocation.


### `RevitBasicFileInfo`
New class for reading Revit basic file information from `.rvt` files without
opening them in Revit.

### Multi-targeting
All Revit projects now multi-target `.NET 8` and `.NET 10`.

## Notes
- Parameters are resolved via `GetRequiredService`; missing registrations throw
  `InvalidOperationException` at runtime.
- The lifetime scope is disposed after each invocation.