### PR TITLE
Added [MeansImplicitUse] to RevitCommand execution attributes

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -7,6 +7,7 @@
 		<PlatformTarget>x64</PlatformTarget>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<Platforms>x64</Platforms>
+		<DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Source/Scotec.Revit/RevitAppBase.cs
+++ b/Source/Scotec.Revit/RevitAppBase.cs
@@ -35,6 +35,7 @@ namespace Scotec.Revit;
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+[JetBrains.Annotations.MeansImplicitUse]
 public sealed class RevitApplicationStartupAttribute : Attribute;
 
 /// <summary>
@@ -58,6 +59,7 @@ public sealed class RevitApplicationStartupAttribute : Attribute;
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+[JetBrains.Annotations.MeansImplicitUse]
 public sealed class RevitApplicationShutdownAttribute : Attribute;
 
 /// <summary>

--- a/Source/Scotec.Revit/RevitCommand.cs
+++ b/Source/Scotec.Revit/RevitCommand.cs
@@ -97,9 +97,8 @@ public enum RevitTransactionMode
 ///     passed through directly. Only one method per type hierarchy may carry this attribute.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class RevitCommandBeforeExecuteAttribute : Attribute
-{
-}
+[JetBrains.Annotations.MeansImplicitUse]
+public sealed class RevitCommandBeforeExecuteAttribute : Attribute;
 
 /// <summary>
 ///     Marks a method as the main execution entry point for a <see cref="RevitCommand" />.
@@ -112,9 +111,8 @@ public sealed class RevitCommandBeforeExecuteAttribute : Attribute
 ///     Only one method per type hierarchy may carry this attribute.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class RevitCommandExecuteAttribute : Attribute
-{
-}
+[JetBrains.Annotations.MeansImplicitUse]
+public sealed class RevitCommandExecuteAttribute : Attribute;
 
 /// <summary>
 ///     Marks a method as the post-execution lifecycle entry point for a <see cref="RevitCommand" />.
@@ -126,9 +124,8 @@ public sealed class RevitCommandExecuteAttribute : Attribute
 ///     passed through directly. Only one method per type hierarchy may carry this attribute.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class RevitCommandAfterExecuteAttribute : Attribute
-{
-}
+[JetBrains.Annotations.MeansImplicitUse]
+public sealed class RevitCommandAfterExecuteAttribute : Attribute;
 
 /// <summary>
 ///     An attribute used to specify the transaction mode for a Revit command.

--- a/Source/Scotec.Revit/RevitCommandAvailability.cs
+++ b/Source/Scotec.Revit/RevitCommandAvailability.cs
@@ -23,9 +23,8 @@ namespace Scotec.Revit;
 ///     directly. Only one method per type hierarchy may carry this attribute.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class RevitCommandAvailabilityCheckAttribute : Attribute
-{
-}
+[JetBrains.Annotations.MeansImplicitUse]
+public sealed class RevitCommandAvailabilityCheckAttribute : Attribute;
 
 /// <summary>
 ///     Represents an abstract base class that determines the availability of external commands in Autodesk Revit.

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -28,6 +28,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Autofac.Extensions.DependencyInjection" />
+		<PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" />
 		<PackageReference Include="OpenMcdf" />
 		<PackageReference Include="Scotec.Extensions.Utilities" />


### PR DESCRIPTION
Added the [MeansImplicitUse](https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#MeansImplicitUseAttribute) to the attributes that can be used to decorate methods that will be called by the framework through reflection. This will make sure consumers avoid having ReSharper or Rider warn about unused methods in their command or application classes when the methods are, in fact, called by the framework through reflection.