### PR TITLE
Downgrade Roslyn, ship analyzers, update diagnostics API

### DIFF
--- a/Source/Directory.Packages.props
+++ b/Source/Directory.Packages.props
@@ -28,7 +28,7 @@
   <!-- Other packages -->
   <ItemGroup>
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageVersion Include="OpenMcdf" Version="3.1.4" />
   </ItemGroup>

--- a/Source/Scotec.Revit.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Scotec.Revit.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,12 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn/blob/main/docs/analyzers/AnalyzerReleases.md
 
+## Release 2027.3.4
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+SCOTEC001 | Usage | Error | RevitTaskRunAnalyzer
+SCOTEC002 | Usage | Warning | RevitTaskRunAnalyzer
+

--- a/Source/Scotec.Revit.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Source/Scotec.Revit.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,5 +5,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-SCOTEC001 | Usage | Error | RevitTaskRunAnalyzer
-SCOTEC002 | Usage | Warning | RevitTaskRunAnalyzer

--- a/Source/Scotec.Revit.Analyzers/RevitTaskRunAnalyzer.cs
+++ b/Source/Scotec.Revit.Analyzers/RevitTaskRunAnalyzer.cs
@@ -55,7 +55,7 @@ public sealed class RevitTaskRunAnalyzer : DiagnosticAnalyzer
 
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        [VoidDelegateOnGenericRun, NonVoidDelegateOnRun];
+        ImmutableArray.Create(VoidDelegateOnGenericRun, NonVoidDelegateOnRun);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)


### PR DESCRIPTION
Downgraded Microsoft.CodeAnalysis.CSharp to 4.8.0. Moved SCOTEC001 and SCOTEC002 rules to shipped analyzers for release 2027.3.4. Refactored SupportedDiagnostics in RevitTaskRunAnalyzer to use ImmutableArray.Create.