### PR TITLE
Fix: Guard Revit context against null document and invalid API objects

### DIFF
--- a/Source/.github/agents/csharp-documentation.agent.md
+++ b/Source/.github/agents/csharp-documentation.agent.md
@@ -1,5 +1,5 @@
 ---
-name: C# Documentation Specialist
+name: C# XML Documentation Specialist
 description: Adds or improves C# XML documentation for public APIs with accurate summaries, params, returns, exceptions, and remarks.
 ---
 
@@ -17,6 +17,8 @@ You are a C# XML documentation specialist.
 - Keep comments concise and useful.
 - Document parameters, return values, exceptions, and remarks where appropriate.
 - Avoid comments that simply repeat member names.
+- Always use fully qualified `<see cref="..."/>` references to avoid ambiguity.
+
 
 ## Rules
 

--- a/Source/Scotec.Revit.Test.slnx
+++ b/Source/Scotec.Revit.Test.slnx
@@ -6,7 +6,9 @@
     <BuildType Name="Revit2027" />
     <Platform Name="x64" />
   </Configurations>
-  <Folder Name="/SolutionItems/" />
+  <Folder Name="/SolutionItems/">
+    <File Path="Directory.Packages.props" />
+  </Folder>
   <Folder Name="/SolutionItems/Documentation/">
     <File Path="../Documentation/RevitAddinIsolation.md" />
     <File Path="../Documentation/RevitApp.md" />

--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -9,7 +9,6 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Scotec.Revit.EventHandler;
 

--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -319,7 +319,6 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
                 ConfigureServices(services);
                 // IRevitContext is always registered.
                 // IRevitUiContext is additionally registered when the context is a UI context.
-                services.AddScoped<IRevitContext>(_ => context!);
                 builder.RegisterInstance(context!).As<IRevitContext>().OwnedByLifetimeScope();
                 if (context is IRevitUiContext uiContext)
                 {

--- a/Source/Scotec.Revit/IRevitContext.cs
+++ b/Source/Scotec.Revit/IRevitContext.cs
@@ -2,21 +2,41 @@
 // Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
 // This file is licensed to you under the MIT license.
 
+using System;
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
 
 namespace Scotec.Revit;
 
+/// <summary>
+///     Provides access to the Revit <see cref="Autodesk.Revit.ApplicationServices.Application" />
+///     and the current <see cref="Autodesk.Revit.DB.Document" /> within the scope of a
+///     Revit event handler or external command.
+/// </summary>
 public interface IRevitContext
 {
     /// <summary>
     ///     Gets the current Revit application.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.ApplicationServices.Application" />
+    ///     is no longer valid.
+    /// </exception>
     Application Application { get; }
 
     /// <summary>
     ///     Gets the current Revit document, or <c>null</c> when no document is available
     ///     (e.g. commands executed without an open document).
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the document reference is non-null and the underlying
+    ///     <see cref="Autodesk.Revit.DB.Document" /> is no longer valid.
+    /// </exception>
     Document? Document { get; }
 }

--- a/Source/Scotec.Revit/IRevitContext.cs
+++ b/Source/Scotec.Revit/IRevitContext.cs
@@ -15,7 +15,8 @@ public interface IRevitContext
     Application Application { get; }
 
     /// <summary>
-    ///     Gets the current Revit document.
+    ///     Gets the current Revit document, or throws <see cref="System.InvalidOperationException" />
+    ///     when no document is available (e.g. commands executed without an open document).
     /// </summary>
-    Document Document { get; }
+    Document? Document { get; }
 }

--- a/Source/Scotec.Revit/IRevitContext.cs
+++ b/Source/Scotec.Revit/IRevitContext.cs
@@ -15,8 +15,8 @@ public interface IRevitContext
     Application Application { get; }
 
     /// <summary>
-    ///     Gets the current Revit document, or throws <see cref="System.InvalidOperationException" />
-    ///     when no document is available (e.g. commands executed without an open document).
+    ///     Gets the current Revit document, or <c>null</c> when no document is available
+    ///     (e.g. commands executed without an open document).
     /// </summary>
     Document? Document { get; }
 }

--- a/Source/Scotec.Revit/IRevitUiContext.cs
+++ b/Source/Scotec.Revit/IRevitUiContext.cs
@@ -15,12 +15,12 @@ public interface IRevitUiContext : IRevitContext
     UIApplication UiApplication { get; }
 
     /// <summary>
-    ///     Gets the current Revit UI document.
+    ///     Gets the current Revit UI document, or <c>null</c> when no document is open.
     /// </summary>
-    UIDocument UiDocument { get; }
+    UIDocument? UiDocument { get; }
 
     /// <summary>
-    ///     Gets the active view in the current Revit UI document.
+    ///     Gets the active view in the current Revit UI document, or <c>null</c> when no document is open.
     /// </summary>
-    View ActiveView { get; }
+    View? ActiveView { get; }
 }

--- a/Source/Scotec.Revit/IRevitUiContext.cs
+++ b/Source/Scotec.Revit/IRevitUiContext.cs
@@ -7,20 +7,51 @@ using Autodesk.Revit.UI;
 
 namespace Scotec.Revit;
 
+/// <summary>
+///     Extends <see cref="IRevitContext" /> with UI-layer access: <see cref="UIApplication" />,
+///     <see cref="IRevitUiContext.UiDocument" />, and <see cref="IRevitUiContext.ActiveView" />.
+/// </summary>
+/// <remarks>
+///     Implemented within the scope of a Revit UI event handler or external command where
+///     a <see cref="UIApplication" /> is available. When no document is open,
+///     <see cref="IRevitUiContext.UiDocument" /> and <see cref="IRevitUiContext.ActiveView" />
+///     return <c>null</c>.
+/// </remarks>
 public interface IRevitUiContext : IRevitContext
 {
     /// <summary>
     ///     Gets the current Revit UI application.
     /// </summary>
+    /// <exception cref="System.ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the underlying <see cref="UIApplication" /> is no longer valid.
+    /// </exception>
     UIApplication UiApplication { get; }
 
     /// <summary>
     ///     Gets the current Revit UI document, or <c>null</c> when no document is open.
     /// </summary>
+    /// <exception cref="System.ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the UI document reference is non-null and the underlying
+    ///     <see cref="UIDocument" /> is no longer valid.
+    /// </exception>
     UIDocument? UiDocument { get; }
 
     /// <summary>
-    ///     Gets the active view in the current Revit UI document, or <c>null</c> when no document is open.
+    ///     Gets the view currently active in <see cref="IRevitUiContext.UiDocument" />,
+    ///     or <c>null</c> when no document is open.
     /// </summary>
+    /// <remarks>
+    ///     Reflects the view active at the moment of access rather than at handler invocation start.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the returned <see cref="View" /> reference is non-null and the underlying
+    ///     <see cref="View" /> is no longer valid.
+    /// </exception>
     View? ActiveView { get; }
 }

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -20,14 +20,26 @@ internal class RevitContext : IRevitContext, IDisposable
 
     public Application Application
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : field;
-        set => field = Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            // Revit API: Application.IsValidObject must be checked before access after potential application lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit application is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
     public Document Document
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : field;
-        set => field = Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            // Revit API: Document.IsValidObject must be checked before access after potential document lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit document is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
     public void Dispose()

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -29,8 +29,7 @@ internal class RevitContext : IRevitContext, IDisposable
     {
         ArgumentNullException.ThrowIfNull(application);
         Application = application;
-        Document = null!;
-        // Document is not set. The Document getter throws InvalidOperationException when accessed.
+        // Document is intentionally left null for no-document contexts.
     }
 
     protected bool Disposed { get; private set; }
@@ -47,14 +46,12 @@ internal class RevitContext : IRevitContext, IDisposable
         private init;
     }
 
-    public Document Document
+    public Document? Document
     {
         get
         {
             ObjectDisposedException.ThrowIf(Disposed, GetType());
-            // ReferenceEquals avoids a false NRT warning: the Revit API is not fully nullable-annotated
-            // so the backing field may be null at runtime even though the property type is non-nullable.
-            if (ReferenceEquals(field, null)) throw new InvalidOperationException("No document is available in the current context.");
+            if (field is null) return null;
             // Revit API: Document.IsValidObject must be checked before access after potential document lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit document is no longer valid.");
             return field;

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -10,10 +10,27 @@ namespace Scotec.Revit;
 
 internal class RevitContext : IRevitContext, IDisposable
 {
+    /// <summary>
+    ///     Initializes a new instance for contexts where a document is available,
+    ///     for example event handlers and transaction commands.
+    /// </summary>
     public RevitContext(Document document)
     {
+        ArgumentNullException.ThrowIfNull(document);
         Document = document;
         Application = document.Application;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance for contexts where no document is required,
+    ///     for example commands that run without an open document.
+    /// </summary>
+    protected RevitContext(Application application)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        Application = application;
+        Document = null!;
+        // Document is not set. The Document getter throws InvalidOperationException when accessed.
     }
 
     protected bool Disposed { get; private set; }
@@ -22,24 +39,28 @@ internal class RevitContext : IRevitContext, IDisposable
     {
         get
         {
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            ObjectDisposedException.ThrowIf(Disposed, GetType());
             // Revit API: Application.IsValidObject must be checked before access after potential application lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit application is no longer valid.");
             return field;
         }
-        private init => field = value;
+        private init;
     }
 
     public Document Document
     {
         get
         {
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            ObjectDisposedException.ThrowIf(Disposed, GetType());
+            // ReferenceEquals avoids a false NRT warning: the Revit API is not fully nullable-annotated
+            // so the backing field may be null at runtime even though the property type is non-nullable.
+            if (ReferenceEquals(field, null)) throw new InvalidOperationException("No document is available in the current context.");
             // Revit API: Document.IsValidObject must be checked before access after potential document lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit document is no longer valid.");
             return field;
         }
-        private init => field = value;
+        // private protected: accessible from RevitUiContext (same assembly, derived type) during construction.
+        private protected init;
     }
 
     public void Dispose()

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -30,7 +30,6 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         get
         {
             ObjectDisposedException.ThrowIf(Disposed, typeof(RevitUiContext));
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
             // Revit API: UIApplication.IsValidObject must be checked before access after potential application lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
             return field;

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -11,38 +11,45 @@ namespace Scotec.Revit;
 internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 {
     public RevitUiContext(UIApplication uiApplication)
-        // Revit API: ActiveUIDocument may be null when no document is open; guard before dereferencing.
-        : base((uiApplication ?? throw new ArgumentNullException(nameof(uiApplication))).ActiveUIDocument?.Document
-               ?? throw new ArgumentException("No active UI document is open.", nameof(uiApplication)))
+        // Revit API: ActiveUIDocument may be null when no document is open.
+        // Pass Application only; Document is set below when a UI document is available.
+        : base((uiApplication ?? throw new ArgumentNullException(nameof(uiApplication))).Application)
     {
         UiApplication = uiApplication;
-        UiDocument = uiApplication.ActiveUIDocument;
+
+        if (uiApplication.ActiveUIDocument is { } uiDocument)
+        {
+            // Set Document on the base class via private protected init.
+            Document = uiDocument.Document;
+            UiDocument = uiDocument;
+        }
     }
 
     public UIApplication UiApplication
     {
         get
         {
+            ObjectDisposedException.ThrowIf(Disposed, typeof(RevitUiContext));
             if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
             // Revit API: UIApplication.IsValidObject must be checked before access after potential application lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
             return field;
         }
-        private init => field = value;
+        private init;
     }
 
-    public UIDocument UiDocument
+    public UIDocument? UiDocument
     {
         get
         {
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
+            ObjectDisposedException.ThrowIf(Disposed, typeof(RevitUiContext));
             // Revit API: UIDocument.IsValidObject must be checked before access after potential document lifecycle events.
-            if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI document is no longer valid.");
+            if (field is not null && !field.IsValidObject) throw new InvalidOperationException("The Revit UI document is no longer valid.");
             return field;
         }
-        private init => field = value;
+        private init;
     }
 
     // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
-    public View ActiveView => UiDocument.ActiveView;
+    public View? ActiveView => UiDocument?.ActiveView;
 }

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -50,5 +50,14 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
     }
 
     // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
-    public View? ActiveView => UiDocument?.ActiveView;
+    // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
+    public View? ActiveView
+    {
+        get
+        {
+            var view = UiDocument?.ActiveView;
+            if (view is not null && !view.IsValidObject) throw new InvalidOperationException("The active Revit view is no longer valid.");
+            return view;
+        }
+    }
 }

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -8,8 +8,36 @@ using Autodesk.Revit.UI;
 
 namespace Scotec.Revit;
 
+/// <summary>
+///     Extends <see cref="RevitContext" /> with UI-layer objects: <see cref="UIApplication" />,
+///     <see cref="RevitUiContext.UiDocument" />, and <see cref="RevitUiContext.ActiveView" />.
+/// </summary>
+/// <remarks>
+///     When no document is open at construction time, <see cref="RevitUiContext.UiDocument" />,
+///     <see cref="RevitContext.Document" />, and <see cref="RevitUiContext.ActiveView" /> are
+///     <c>null</c>; <see cref="RevitUiContext.UiApplication" /> and
+///     <see cref="RevitContext.Application" /> are always set.
+///     <para>
+///         All property accessors throw <see cref="ObjectDisposedException" /> after
+///         <see cref="RevitContext.Dispose" /> has been called, and
+///         <see cref="InvalidOperationException" /> when the underlying Revit API object is
+///         no longer valid.
+///     </para>
+/// </remarks>
 internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 {
+    /// <summary>
+    ///     Initializes a new instance from the given <see cref="UIApplication" />.
+    /// </summary>
+    /// <param name="uiApplication">The active Revit UI application.</param>
+    /// <remarks>
+    ///     When <see cref="UIApplication.ActiveUIDocument" /> is non-null at construction time,
+    ///     <see cref="RevitContext.Document" /> and <see cref="RevitUiContext.UiDocument" /> are
+    ///     populated. Otherwise both remain <c>null</c>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="uiApplication" /> is <c>null</c>.
+    /// </exception>
     public RevitUiContext(UIApplication uiApplication)
         // Revit API: ActiveUIDocument may be null when no document is open.
         // Pass Application only; Document is set below when a UI document is available.
@@ -25,6 +53,16 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         }
     }
 
+    /// <summary>
+    ///     Gets the Revit UI application.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when <see cref="UIApplication.IsValidObject" /> returns <c>false</c>,
+    ///     indicating the UI application object is no longer valid.
+    /// </exception>
     public UIApplication UiApplication
     {
         get
@@ -37,6 +75,18 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         private init;
     }
 
+    /// <summary>
+    ///     Gets the active Revit UI document, or <c>null</c> when no document was open at
+    ///     construction time.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the UI document reference is non-null and
+    ///     <see cref="UIDocument.IsValidObject" /> returns <c>false</c>,
+    ///     indicating the document has been closed or invalidated.
+    /// </exception>
     public UIDocument? UiDocument
     {
         get
@@ -49,7 +99,19 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         private init;
     }
 
-    // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
+    /// <summary>
+    ///     Gets the view currently active in <see cref="RevitUiContext.UiDocument" />, or
+    ///     <c>null</c> when no document is open.
+    /// </summary>
+    /// <remarks>
+    ///     This is a lazy property: it reflects the view active at the moment of access
+    ///     rather than at handler invocation start.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the returned <see cref="View" /> reference is non-null and
+    ///     <see cref="View.IsValidObject" /> returns <c>false</c>,
+    ///     indicating the view has been closed or invalidated.
+    /// </exception>
     // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
     public View? ActiveView
     {

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -10,7 +10,10 @@ namespace Scotec.Revit;
 
 internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 {
-    public RevitUiContext(UIApplication uiApplication) : base(uiApplication.ActiveUIDocument.Document)
+    public RevitUiContext(UIApplication uiApplication)
+        // Revit API: ActiveUIDocument may be null when no document is open; guard before dereferencing.
+        : base((uiApplication ?? throw new ArgumentNullException(nameof(uiApplication))).ActiveUIDocument?.Document
+               ?? throw new ArgumentException("No active UI document is open.", nameof(uiApplication)))
     {
         UiApplication = uiApplication;
         UiDocument = uiApplication.ActiveUIDocument;
@@ -18,16 +21,28 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 
     public UIApplication UiApplication
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : field;
-        private init => field = Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
+            // Revit API: UIApplication.IsValidObject must be checked before access after potential application lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
     public UIDocument UiDocument
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : field;
-        private init => field = Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
+            // Revit API: UIDocument.IsValidObject must be checked before access after potential document lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI document is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
-    // Lazy property, to reflect the view active at the moment of access rather than at handler invocation start.
+    // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
     public View ActiveView => UiDocument.ActiveView;
 }


### PR DESCRIPTION
## What Changed

### Revit API — `RevitContext`
- `Document` getter migrated from an inline disposed ternary to `ObjectDisposedException.ThrowIf`
  followed by a `Document.IsValidObject` check, guarding against stale document references
  after Revit document lifecycle events.
- `Document` setter changed from `private set` to `private protected init`, allowing
  `RevitUiContext` to assign it during construction while keeping it inaccessible to
  external consumers.
- `Document` return type changed to `Document?`; getter short-circuits to `null` when the
  backing field is unset.

### Revit API — `RevitUiContext`
- Constructor previously called `base(uiApplication.ActiveUIDocument.Document)`, which
  throws a `NullReferenceException` when no document is open. It now passes `Application`
  only and conditionally initialises `Document` and `UiDocument` when `ActiveUIDocument`
  is non-null.
- Added `ArgumentNullException` guard for the `uiApplication` constructor parameter.
- `UiApplication` and `UiDocument` getters migrated from inline disposed ternary
  expressions to `ObjectDisposedException.ThrowIf` plus `IsValidObject` validation.
- `UiDocument` return type changed from `UIDocument` to `UIDocument?`.
- `ActiveView` return type changed from `View` to `View?`. Getter now validates
  `View.IsValidObject` before returning, consistent with guards on `UiApplication`
  and `UiDocument`.

### Revit API — `RevitEventHandler`
- Removed 2 lines superseded by the validity guards introduced in the context classes.

### Interfaces — `IRevitContext` / `IRevitUiContext`
- `Document` on `IRevitContext` is now `Document?`.
- `UiDocument` and `ActiveView` on `IRevitUiContext` are now nullable.

### Documentation
- Full XML doc applied to `RevitContext`, `RevitUiContext`, `IRevitContext`, and
  `IRevitUiContext`, including `<summary>`, `<remarks>`, `<param>`, and `<exception>`
  tags on all members. All `<see cref>` references are fully qualified to avoid
  ambiguous-reference warnings.

### Test Solution
- `Scotec.Revit.Test.slnx` updated to reflect the new project structure.

## Bugs Fixed
- `RevitUiContext` threw `NullReferenceException` when constructed outside an active
  document session (e.g. during application startup or in a document-closed event handler).
  Root cause: unconditional access to `ActiveUIDocument.Document` in the base constructor call.
- `ActiveView` returned a potentially stale `View` reference without validating
  `IsValidObject`, unlike the guards applied consistently to all other context properties.

## Breaking Changes
- `IRevitContext.Document` is now `Document?`. All callers that treated this as non-nullable
  must add null handling.
- `IRevitUiContext.UiDocument` is now `UIDocument?`. Same applies.
- `IRevitUiContext.ActiveView` is now `View?`. Same applies.
- Code relying on the previous `NullReferenceException` from the `RevitUiContext`
  constructor when no document is open will now receive a clean `ArgumentNullException`
  (null `UIApplication`) or construct successfully with `UiDocument` and `Document`
  as `null`.

## Risks
- All existing consumers of `IRevitContext.Document`, `IRevitUiContext.UiDocument`, and
  `ActiveView` must be audited for unguarded dereferences now that the return types are
  nullable.
- The `private protected init` modifier on `Document` relies on C# field keyword
  semantics (C# 14); verify compiler compatibility across all build targets.