### PR TITLE
Revit context

### DIFF
--- a/Documentation/RevitContext.md
+++ b/Documentation/RevitContext.md
@@ -1,0 +1,294 @@
+# Revit Context Interfaces
+
+This document explains the context interfaces in the `Scotec.Revit` framework, when to use each one, how they are registered, and the mistakes to avoid.
+
+## Overview
+
+The framework provides two distinct groups of context interfaces, each with a different lifetime and purpose.
+
+| Interface | Lifetime | Available |
+|---|---|---|
+| `IRevitContext` | Scoped — per event invocation or command execution | Only inside an active Revit callback |
+| `IRevitUiContext` | Scoped — per event invocation or command execution | Only inside an active Revit UI callback |
+| `IGlobalRevitContext` | Singleton — entire add-in lifetime | Always, from any component |
+| `IGlobalRevitUiContext` | Singleton — entire add-in lifetime | Always, from any component |
+
+---
+
+## Scoped Contexts
+
+### `IRevitContext`
+
+Provides access to `Application` and `Document` within the scope of a single Revit event handler or external command invocation. The context is created by the framework at the start of each invocation and disposed at the end.
+
+```
+Application   — always set
+Document      — set when a document is open; null otherwise
+```
+
+Use `IRevitContext` when your service or handler needs to read or write document data.
+
+```csharp
+public class MyDocumentHandler : RevitEventHandler<..., IRevitContext>
+{
+	protected override void OnExecute(IRevitContext context)
+	{
+		var doc = context.Document;
+		// Read or write document data here.
+	}
+}
+```
+
+`Document` may be `null` for commands that do not require an open document. Always null-check before use.
+
+---
+
+### `IRevitUiContext`
+
+Extends `IRevitContext` with UI-layer access: `UiApplication`, `UiDocument`, and `ActiveView`. Use this when your handler or command also needs ribbon interaction, selection, or active view access.
+
+```
+UiApplication — always set
+UiDocument    — set when a document is open; null otherwise
+ActiveView    — reflects the view active at the moment of access; null when no document is open
+```
+
+```csharp
+public class MyUiHandler : RevitEventHandler<..., IRevitUiContext>
+{
+	protected override void OnExecute(IRevitUiContext context)
+	{
+		var view = context.ActiveView;
+		// Interact with the active view.
+	}
+}
+```
+
+Note that `ActiveView` is evaluated lazily — it reflects the view that is active when you read the property, not the view that was active when the event fired.
+
+---
+
+### Injection inside scoped services
+
+Scoped contexts are registered automatically in the per-invocation DI scope. Inject them via the constructor of any service that is resolved within that scope.
+
+```csharp
+public class MyService
+{
+	private readonly IRevitUiContext _context;
+
+	public MyService(IRevitUiContext context)
+	{
+		_context = context;
+	}
+
+	public void DoWork()
+	{
+		var doc = _context.Document;
+		// ...
+	}
+}
+```
+
+---
+
+## Global (Singleton) Contexts
+
+Global contexts are singletons registered in the root DI container at add-in startup. They are always resolvable, regardless of whether a Revit callback is currently executing.
+
+> **Important:** Global contexts are intended for lightweight checks — ribbon state, command availability, and service initialisation. They are not a substitute for the scoped `IRevitContext`. Document data should be accessed inside a scoped context, not through a singleton.
+
+---
+
+### `IGlobalRevitContext`
+
+Provides singleton access to `Application`. Available in both `RevitApp`- and `RevitDbApp`-based add-ins.
+In a `RevitApp` add-in it is satisfied by the same `GlobalRevitUiContext` instance that implements `IGlobalRevitUiContext`.
+
+```
+Application — available after ApplicationInitialized fires; throws before that
+```
+
+Typical uses from singleton services:
+
+- Reading stable session metadata: `VersionNumber`, `Language`, `SharedParametersFilename`
+- Iterating all currently open documents via `Application.Documents`
+
+```csharp
+public class MyService
+{
+    private readonly IGlobalRevitContext _context;
+
+    public MyService(IGlobalRevitContext context)
+    {
+        _context = context;
+    }
+
+    public IEnumerable<string> GetOpenDocumentPaths()
+    {
+        foreach (Document doc in _context.Application.Documents)
+            yield return doc.PathName;
+    }
+}
+```
+
+Note that `Application.Documents` reflects open documents at the moment of the call. Iterating it outside a Revit API context (i.e. not inside an event handler or command) requires care: documents may be opened or closed concurrently by the user.
+
+---
+
+### `IGlobalRevitUiContext`
+
+Extends `IGlobalRevitContext` with `UiApplication`, `UiDocument`, `ActiveDocument`, and `ActiveView`.
+Only available in `RevitApp`-based add-ins. Not registered in `RevitDbApp`-based add-ins.
+
+```
+UiApplication  — throws if the underlying UIApplication is no longer valid
+UiDocument     — null when no document is open
+ActiveDocument — null when no document is open
+ActiveView     — null when no document is open; throws if the view is no longer valid
+```
+
+All document-related members reflect the state **at the moment of access**. They may change or become null between consecutive reads if the user opens or closes a document.
+
+---
+
+## Registration
+
+Global contexts are registered automatically by the framework inside `RevitApp.OnConfigure` and `RevitDbApp.OnConfigure` through the `AddGlobalRevitContext` extension method. **No manual registration is required.**
+
+### For `RevitApp`-based add-ins
+
+`OnConfigure` calls:
+
+```csharp
+services.AddGlobalRevitContext(Application); // Application is UIControlledApplication
+```
+
+This registers a single `GlobalRevitUiContext` instance as both `IGlobalRevitUiContext` and `IGlobalRevitContext`.
+
+### For `RevitDbApp`-based add-ins
+
+`OnConfigure` calls:
+
+```csharp
+services.AddGlobalRevitContext(Application); // Application is ControlledApplication
+```
+
+This registers a `GlobalRevitContext` instance as `IGlobalRevitContext` only. `IGlobalRevitUiContext` is not available.
+
+### Manual registration (advanced)
+
+If you are building a host outside of `RevitApp` or `RevitDbApp`, call the extension methods explicitly in your `OnConfigure` override:
+
+```csharp
+// UI add-in
+builder.ConfigureServices(services =>
+{
+	services.AddGlobalRevitContext(uiControlledApplication);
+});
+
+// DB add-in
+builder.ConfigureServices(services =>
+{
+	services.AddGlobalRevitContext(controlledApplication);
+});
+```
+
+---
+
+## Common Mistakes
+
+### Injecting a scoped context into a singleton
+
+`IRevitContext` and `IRevitUiContext` are scoped. Injecting them into a singleton service will either fail at resolution time or produce a captured, already-disposed context.
+
+```csharp
+// Wrong — IRevitContext is scoped; this singleton will capture a disposed context.
+public class MySingletonService
+{
+	public MySingletonService(IRevitContext context) { ... }
+}
+```
+
+Use `IGlobalRevitContext` or `IGlobalRevitUiContext` in singleton services, or restructure so document access happens in a scoped component.
+
+---
+
+### Accessing `Document` from the global context
+
+Neither `IGlobalRevitContext` nor `IGlobalRevitUiContext` exposes a `Document` property. `ActiveDocument` on `IGlobalRevitUiContext` returns the currently open document, but it may be `null` and may change at any time. It is not safe for transactional document access.
+
+```csharp
+// Risky — ActiveDocument may be null or change between the null-check and the transaction.
+var doc = _globalUiContext.ActiveDocument;
+transaction.Start(); // doc may be stale or null
+```
+
+Transactional access and any work that reads or modifies document elements belongs inside a scoped `IRevitContext`, obtained from a command or event handler.
+
+---
+
+### Accessing `Application` before `ApplicationInitialized`
+
+`GlobalRevitContext.Application` is not set until Revit fires the `ApplicationInitialized` event. Accessing it before that event throws `InvalidOperationException`. This can happen if a hosted service resolves `IGlobalRevitContext` during its own startup before the event has fired.
+
+```csharp
+// May throw if the hosted service starts before ApplicationInitialized.
+public class MyHostedService : IHostedService
+{
+	public MyHostedService(IGlobalRevitContext context)
+	{
+		_ = context.Application; // Unsafe here — event may not have fired yet.
+	}
+}
+```
+
+Defer access to `Application` until after the `ApplicationInitialized` event, or access it only inside methods that are called at or after that point.
+
+---
+
+### Storing a scoped context beyond the invocation scope
+
+A scoped context is disposed at the end of the invocation that created it. Storing it in a field and reading it later will throw `ObjectDisposedException`.
+
+```csharp
+// Wrong — context is disposed after the handler returns.
+public class MyHandler : RevitEventHandler<..., IRevitContext>
+{
+	private IRevitContext? _stored;
+
+	protected override void OnExecute(IRevitContext context)
+	{
+		_stored = context; // Never do this.
+	}
+
+	public void Later() => _ = _stored!.Document; // Throws ObjectDisposedException.
+}
+```
+
+---
+
+## Interface Hierarchy
+
+```
+IGlobalRevitContext
+	└── IGlobalRevitUiContext
+
+IRevitContext
+	└── IRevitUiContext
+```
+
+The global and scoped hierarchies are independent. There is no inheritance relationship between them.
+
+---
+
+## Quick Reference
+
+| Need | Use |
+|---|---|
+| Read or write document data inside a command or event handler | `IRevitContext` |
+| Access the active view or UIDocument inside a command or event handler | `IRevitUiContext` |
+| Read stable application metadata (language, version, paths) or iterate open documents from a singleton service | `IGlobalRevitContext` |
+| Check ribbon state or command availability from a singleton service | `IGlobalRevitUiContext` |
+| Handle Revit events | `RevitEventHandler<>` — not the context interfaces |
+| Do transactional document work from a singleton | Restructure — use a scoped context |

--- a/Documentation/RevitContextDesign.md
+++ b/Documentation/RevitContextDesign.md
@@ -23,7 +23,7 @@ internal class CurrentDocumentProvider : ICurrentDocumentProvider, IDisposable
 	private void OnViewActivated(object sender, ViewActivatedEventArgs e)
 	{
 		_activeDocument   = e.Document;
-		_activeUiDocument = ((UIApplication)sender).ActiveUIDocument;
+		_activeUiDocument = new UIDocument(e.Document);
 	}
 
 	public void Dispose()
@@ -40,11 +40,11 @@ This looks convenient, but it introduces a set of structural problems.
 | Issue | `CurrentDocumentProvider` | `IRevitContext` / `IRevitUiContext` |
 |---|---|---|
 | **Staleness** | Holds the *last seen* document — may already be closed | Created from the *current event sender* — always correct for this invocation |
-| **Thread safety** | `volatile` guards the reference, but Revit API objects are only valid on the Revit main thread — a background thread that reads the cached reference cannot call any API on it | Not shared; confined to the event call stack on the Revit main thread |
+| **Thread safety** | Needs `volatile`, possibly locks | Not shared; no concurrent access possible |
 | **Revit API lifetime** | `Document` / `UIDocument` can become invalid between event and consumption | Consumed within the scope created by the event — same call stack |
-| **Coupling** | Consumers get `null` until `ViewActivated` has fired at least once; no document is available at startup until the user activates a view | No ordering dependency; context is injected by the framework at the right moment |
-| **Subscription management** | Must implement `IDisposable`, ensure the container disposes it, and unsubscribe during shutdown to prevent callbacks firing during teardown | No manual subscription; the framework subscribes and unsubscribes automatically |
-| **Testability** | Requires mocking `UIControlledApplication` and raising `ViewActivated` in the right sequence to put the provider in a testable state | Inject a mock `IRevitContext` — one line |
+| **Coupling** | Consumers depend on `DocumentActivatedEvent` having fired *first* | No ordering dependency; context is injected by the framework at the right moment |
+| **Subscription leaks** | Must `Dispose()` to unsubscribe; forgetting causes a memory leak | No manual subscription; DI scope disposal handles cleanup |
+| **Testability** | Requires wiring an event aggregator and firing events in sequence | Inject a mock `IRevitContext` — one line |
 
 ## Why the Scoped Context Wins
 
@@ -63,9 +63,9 @@ Revit fires event
 The singleton provider tries to simulate this by watching events, but it is a simulation that can be
 wrong whenever:
 
-- `ViewActivated` does not fire when a document is closed. The cached reference remains set after closure, pointing to an invalid `Document` object.
-- The document is closed before the consumer acts on the cached reference.
-- A handler is invoked while the active document has changed since the last `ViewActivated` fired.
+- Events arrive out of order.
+- The document is closed before the consumer acts.
+- A handler is invoked on a different activation state than expected.
 
 ## The Design Principle
 

--- a/Documentation/RevitContextDesign.md
+++ b/Documentation/RevitContextDesign.md
@@ -2,7 +2,9 @@
 
 ## The Problem with Singleton Document Providers
 
-A common pattern in Revit add-ins is a singleton service that caches the active document by listening to Revit events:
+The following implementation illustrates a pattern that looks convenient at first glance —
+a singleton service that caches the active document by listening to Revit events,
+intended to make the document available to commands and other services:
 
 ```csharp
 internal class CurrentDocumentProvider : ICurrentDocumentProvider, IDisposable
@@ -40,80 +42,110 @@ This looks convenient, but it introduces a set of structural problems.
 | Issue | `CurrentDocumentProvider` | `IRevitContext` / `IRevitUiContext` |
 |---|---|---|
 | **Staleness** | Holds the *last seen* document — may already be closed | Created from the *current event sender* — always correct for this invocation |
-| **Thread safety** | Needs `volatile`, possibly locks | Not shared; no concurrent access possible |
+| **Thread safety** | `volatile` is a code smell here — all Revit API access must happen on the Revit main thread, and Revit events fire on that thread. Neither `volatile` nor locks can make a cached Revit object safe to use from a background thread; that is a Revit threading violation regardless | Not shared; confined to the event call stack on the Revit main thread |
 | **Revit API lifetime** | `Document` / `UIDocument` can become invalid between event and consumption | Consumed within the scope created by the event — same call stack |
-| **Coupling** | Consumers depend on `DocumentActivatedEvent` having fired *first* | No ordering dependency; context is injected by the framework at the right moment |
-| **Subscription leaks** | Must `Dispose()` to unsubscribe; forgetting causes a memory leak | No manual subscription; DI scope disposal handles cleanup |
-| **Testability** | Requires wiring an event aggregator and firing events in sequence | Inject a mock `IRevitContext` — one line |
+| **Coupling** | Consumers get `null` until `ViewActivated` has fired at least once; no document is available at startup until the user activates a view | No ordering dependency; context is injected by the framework at the right moment |
+| **Subscription management** | Must implement `IDisposable`, ensure the container disposes it, and unsubscribe during shutdown to prevent callbacks firing during teardown | No manual subscription; the framework subscribes and unsubscribes automatically |
+| **Testability** | Requires mocking `UIControlledApplication` and raising `ViewActivated` in the right sequence to put the provider in a testable state | Inject a mock `IRevitContext` — one line |
 
 ## Why the Scoped Context Wins
 
-A Revit event handler has a precise, bounded lifetime: **start of event callback → end of event callback**.
-`IRevitContext` and `IRevitUiContext` model exactly that with a per-invocation DI scope:
+Both command execution and event handling have a precise, bounded lifetime:
+**start of invocation → end of invocation**.
+`IRevitUiContext` (commands) and `IRevitContext` / `IRevitUiContext` (event handlers) model exactly
+that with a per-invocation DI scope.
+
+**Command execution:**
+
+```
+Revit invokes IExternalCommand.Execute
+  → framework creates RevitUiContext from commandData.Application
+  → child DI scope opened; IRevitUiContext and IRevitContext registered
+  → services resolve IRevitUiContext from scope (always the right document)
+  → command logic executes
+  → scope disposed → context disposed
+```
+
+**Event handling:**
 
 ```
 Revit fires event
   → HandleEvent creates child DI scope
   → CreateContext captures sender/args into IRevitContext
-  → Services resolve IRevitContext from scope (always the right document)
-  → Handler logic executes
-  → Scope disposed → context disposed
+  → services resolve IRevitContext from scope (always the right document)
+  → handler logic executes
+  → scope disposed → context disposed
 ```
 
 The singleton provider tries to simulate this by watching events, but it is a simulation that can be
 wrong whenever:
 
-- Events arrive out of order.
-- The document is closed before the consumer acts.
-- A handler is invoked on a different activation state than expected.
+- `ViewActivated` does not fire when a document is closed — the cached reference stays set after closure, pointing to an invalid `Document` object that will throw on any API access.
+- A handler runs while the active document has changed since the last `ViewActivated` fired.
 
 ## The Design Principle
 
 > `CurrentDocumentProvider` answers *"what was the last document Revit told me about?"*
 >
-> `IRevitContext` answers *"what is the document for the event currently executing?"*
+> `IRevitUiContext` in a command answers *"what is the document the user invoked this command against?"*
 
 Only the second question has a guaranteed correct answer.
 The first is eventually-consistent at best.
 
 ## Usage Example
 
-Instead of injecting a singleton provider:
+Instead of injecting a singleton provider into a service that commands call:
 
 ```csharp
 // ❌ Singleton — may be stale
 public class MyService(ICurrentDocumentProvider provider)
 {
-	public void DoWork()
+	public Result DoWork()
 	{
 		var doc = provider.ActiveDocument; // could be null or already closed
 	}
 }
 ```
 
-Inject the scoped context directly into a handler. The recommended approach uses `AddHandler()` with a
-delegate whose parameters are resolved from the per-invocation DI scope:
+Inject `IRevitUiContext` directly into the command. The recommended approach uses a method
+marked with `[RevitCommandExecute]` whose parameters are all resolved from the per-invocation DI scope:
 
 ```csharp
-// ✅ Scoped — always matches the current event
-public class MyDocumentOpenedHandler : RevitDocumentOpenedHandler
+// ✅ Scoped — always the document the user invoked the command against
+[RevitTransactionMode(RevitTransactionMode.Transaction)]
+public class MyCommand : RevitCommand
 {
-	public MyDocumentOpenedHandler(ControlledApplication application, IMyService service)
-		: base(application)
+	[RevitCommandExecute]
+	protected Result Execute(IRevitUiContext context, IMyService service)
 	{
-		AddHandler((IRevitContext context) =>
-			service.DoWork(context.Document!)); // document guaranteed valid here
+		var doc = context.Document!; // document guaranteed valid here
+		return service.DoWork(doc);
 	}
 }
 ```
 
-`RevitDocumentOpenedHandler` already subscribes to `Application.DocumentOpened` in its constructor.
-The `AddHandler` delegate receives `IRevitContext` resolved from the per-invocation DI scope.
+The framework creates `IRevitUiContext` from `commandData.Application`, registers it in the
+per-invocation DI scope alongside `IRevitContext`, and disposes the scope when the command returns.
 
-Alternatively, use the `[RevitEventHandlerExecute]` attribute on a method with any combination of
-DI-resolved parameters:
+For commands that only need document access without UI objects, inject `IRevitContext` instead:
 
 ```csharp
+[RevitCommandExecute]
+protected Result Execute(IRevitContext context, IMyService service)
+{
+	return service.DoWork(context.Document!);
+}
+```
+
+---
+
+### Event Handler Example
+
+The same principle applies to event handlers. The recommended approach uses `[RevitEventHandlerExecute]`
+with DI-resolved parameters:
+
+```csharp
+// ✅ Scoped — always matches the current event
 public class MyDocumentOpenedHandler : RevitDocumentOpenedHandler
 {
 	private readonly IMyService _service;
@@ -132,6 +164,20 @@ public class MyDocumentOpenedHandler : RevitDocumentOpenedHandler
 }
 ```
 
+Alternatively, use `AddHandler()` with a delegate:
+
+```csharp
+public class MyDocumentOpenedHandler : RevitDocumentOpenedHandler
+{
+	public MyDocumentOpenedHandler(ControlledApplication application, IMyService service)
+		: base(application)
+	{
+		AddHandler((IRevitContext context) =>
+			service.DoWork(context.Document!)); // document guaranteed valid here
+	}
+}
+```
+
+`RevitDocumentOpenedHandler` already subscribes to `Application.DocumentOpened` in its constructor.
 The framework creates the `IRevitContext` from the event arguments, registers it in the per-invocation
-DI scope, and disposes the scope — and the context — when the handler returns.
-No global state, no manual subscription management, no staleness.
+DI scope, and disposes the scope when the handler returns.

--- a/Documentation/RevitContextDesign.md
+++ b/Documentation/RevitContextDesign.md
@@ -9,20 +9,26 @@ internal class CurrentDocumentProvider : ICurrentDocumentProvider, IDisposable
 {
 	private volatile Document?   _activeDocument;
 	private volatile UIDocument? _activeUiDocument;
+	private readonly UIControlledApplication _application;
 
 	public Document?   ActiveDocument   => _activeDocument;
 	public UIDocument? ActiveUiDocument => _activeUiDocument;
 
-	public CurrentDocumentProvider(IEventAggregator eventAggregator)
+	public CurrentDocumentProvider(UIControlledApplication application)
 	{
-		_subscriptionToken = eventAggregator.Subscribe<DocumentActivatedEvent>(
-			OnCurrentDocumentActivatedEvent);
+		_application = application;
+		_application.ViewActivated += OnViewActivated;
 	}
 
-	private void OnCurrentDocumentActivatedEvent(DocumentActivatedEvent e)
+	private void OnViewActivated(object sender, ViewActivatedEventArgs e)
 	{
 		_activeDocument   = e.Document;
-		_activeUiDocument = new UIDocument(_activeDocument);
+		_activeUiDocument = ((UIApplication)sender).ActiveUIDocument;
+	}
+
+	public void Dispose()
+	{
+		_application.ViewActivated -= OnViewActivated;
 	}
 }
 ```
@@ -34,11 +40,11 @@ This looks convenient, but it introduces a set of structural problems.
 | Issue | `CurrentDocumentProvider` | `IRevitContext` / `IRevitUiContext` |
 |---|---|---|
 | **Staleness** | Holds the *last seen* document — may already be closed | Created from the *current event sender* — always correct for this invocation |
-| **Thread safety** | Needs `volatile`, possibly locks | Not shared; no concurrent access possible |
+| **Thread safety** | `volatile` guards the reference, but Revit API objects are only valid on the Revit main thread — a background thread that reads the cached reference cannot call any API on it | Not shared; confined to the event call stack on the Revit main thread |
 | **Revit API lifetime** | `Document` / `UIDocument` can become invalid between event and consumption | Consumed within the scope created by the event — same call stack |
-| **Coupling** | Consumers depend on `DocumentActivatedEvent` having fired *first* | No ordering dependency; context is injected by the framework at the right moment |
-| **Subscription leaks** | Must `Dispose()` to unsubscribe; forgetting causes a memory leak | No manual subscription; DI scope disposal handles cleanup |
-| **Testability** | Requires wiring an event aggregator and firing events in sequence | Inject a mock `IRevitContext` — one line |
+| **Coupling** | Consumers get `null` until `ViewActivated` has fired at least once; no document is available at startup until the user activates a view | No ordering dependency; context is injected by the framework at the right moment |
+| **Subscription management** | Must implement `IDisposable`, ensure the container disposes it, and unsubscribe during shutdown to prevent callbacks firing during teardown | No manual subscription; the framework subscribes and unsubscribes automatically |
+| **Testability** | Requires mocking `UIControlledApplication` and raising `ViewActivated` in the right sequence to put the provider in a testable state | Inject a mock `IRevitContext` — one line |
 
 ## Why the Scoped Context Wins
 
@@ -57,9 +63,9 @@ Revit fires event
 The singleton provider tries to simulate this by watching events, but it is a simulation that can be
 wrong whenever:
 
-- Events arrive out of order.
-- The document is closed before the consumer acts.
-- A handler is invoked on a different activation state than expected.
+- `ViewActivated` does not fire when a document is closed. The cached reference remains set after closure, pointing to an invalid `Document` object.
+- The document is closed before the consumer acts on the cached reference.
+- A handler is invoked while the active document has changed since the last `ViewActivated` fired.
 
 ## The Design Principle
 
@@ -85,30 +91,44 @@ public class MyService(ICurrentDocumentProvider provider)
 }
 ```
 
-Inject the scoped context directly into a handler:
+Inject the scoped context directly into a handler. The recommended approach uses `AddHandler()` with a
+delegate whose parameters are resolved from the per-invocation DI scope:
 
 ```csharp
 // ✅ Scoped — always matches the current event
-public class MyDocumentOpenedHandler : RevitAppPostDocumentEventHandler<DocumentOpenedEventArgs>
+public class MyDocumentOpenedHandler : RevitDocumentOpenedHandler
+{
+	public MyDocumentOpenedHandler(ControlledApplication application, IMyService service)
+		: base(application)
+	{
+		AddHandler((IRevitContext context) =>
+			service.DoWork(context.Document!)); // document guaranteed valid here
+	}
+}
+```
+
+`RevitDocumentOpenedHandler` already subscribes to `Application.DocumentOpened` in its constructor.
+The `AddHandler` delegate receives `IRevitContext` resolved from the per-invocation DI scope.
+
+Alternatively, use the `[RevitEventHandlerExecute]` attribute on a method with any combination of
+DI-resolved parameters:
+
+```csharp
+public class MyDocumentOpenedHandler : RevitDocumentOpenedHandler
 {
 	private readonly IMyService _service;
 
-	protected MyDocumentOpenedHandler(ControlledApplication application, IMyService service)
+	public MyDocumentOpenedHandler(ControlledApplication application, IMyService service)
 		: base(application)
 	{
 		_service = service;
 	}
 
-	protected override Task OnExecuteAsync(
-		DocumentOpenedEventArgs args,
-		IRevitContext context,          // document guaranteed valid here
-		CancellationToken cancellationToken)
+	[RevitEventHandlerExecute]
+	protected void Execute(IRevitContext context, DocumentOpenedEventArgs args)
 	{
-		return _service.DoWorkAsync(context.Document, cancellationToken);
+		_service.DoWork(context.Document!); // document guaranteed valid here
 	}
-
-	protected sealed override void Subscribe()   => Application.DocumentOpened += HandleEvent;
-	protected sealed override void Unsubscribe() => Application.DocumentOpened -= HandleEvent;
 }
 ```
 

--- a/Source/.github/agents/csharp-documentation.agent.md
+++ b/Source/.github/agents/csharp-documentation.agent.md
@@ -17,15 +17,15 @@ You are a C# XML documentation specialist.
 - Keep comments concise and useful.
 - Document parameters, return values, exceptions, and remarks where appropriate.
 - Avoid comments that simply repeat member names.
-- Always use fully qualified `<see cref="..."/>` references to avoid ambiguity.
+- Always use fully qualified `<see cref="Scotec.Revit.IRevitContext"/>` references to avoid ambiguity.
 
 
 ## Rules
 
 - Documentation must match actual behavior.
 - Do not invent behavior not visible in the code.
-- Use `<see cref="..."/>` where helpful.
-- Use `<exception cref="...">` for documented exceptions.
+- Use `<see cref="Scotec.Revit.IRevitContext"/>` where helpful.
+- Use `<exception cref="System.Exception"/>` for documented exceptions.
 - Prefer clarity over verbosity.
 
 ## Verification

--- a/Source/.github/agents/csharp-documentation.agent.md
+++ b/Source/.github/agents/csharp-documentation.agent.md
@@ -1,5 +1,5 @@
 ---
-name: C# Documentation Specialist
+name: C# XML Documentation Specialist
 description: Adds or improves C# XML documentation for public APIs with accurate summaries, params, returns, exceptions, and remarks.
 ---
 
@@ -17,6 +17,8 @@ You are a C# XML documentation specialist.
 - Keep comments concise and useful.
 - Document parameters, return values, exceptions, and remarks where appropriate.
 - Avoid comments that simply repeat member names.
+- Always use fully qualified `<see cref="..."/>` references to avoid ambiguity.
+
 
 ## Rules
 

--- a/Source/.github/instructions/documentation.instructions.md
+++ b/Source/.github/instructions/documentation.instructions.md
@@ -41,6 +41,6 @@ When writing user-facing documentation:
 
 - Start with the purpose.
 - Explain the workflow.
-- Include examples.
+- Include examples if they provide additional value.
 - Avoid implementation details unless relevant.
 - Keep wording clear and professional.

--- a/Source/.github/skills/xml-docs/SKILL.md
+++ b/Source/.github/skills/xml-docs/SKILL.md
@@ -95,6 +95,6 @@ Use `<see>` and `<seealso>` where helpful.
 
 Prefer strongly typed references:
 
-```csharp
-<see cref="IContentStorage"/>
+```xml
+<see cref="Scotec.Revit.IRevitContext"/>
 ```

--- a/Source/Scotec.Revit.Test.slnx
+++ b/Source/Scotec.Revit.Test.slnx
@@ -6,7 +6,9 @@
     <BuildType Name="Revit2027" />
     <Platform Name="x64" />
   </Configurations>
-  <Folder Name="/SolutionItems/" />
+  <Folder Name="/SolutionItems/">
+    <File Path="Directory.Packages.props" />
+  </Folder>
   <Folder Name="/SolutionItems/Documentation/">
     <File Path="../Documentation/RevitAddinIsolation.md" />
     <File Path="../Documentation/RevitApp.md" />

--- a/Source/Scotec.Revit.Test.slnx
+++ b/Source/Scotec.Revit.Test.slnx
@@ -14,6 +14,7 @@
     <File Path="../Documentation/RevitApp.md" />
     <File Path="../Documentation/RevitCommand.md" />
     <File Path="../Documentation/RevitCommandAvailability.md" />
+    <File Path="../Documentation/RevitContext.md" />
     <File Path="../Documentation/RevitEventHandler.md" />
     <File Path="../Documentation/RevitTask.md" />
     <File Path="../Documentation/RevitUpdater.md" />

--- a/Source/Scotec.Revit.Test.slnx
+++ b/Source/Scotec.Revit.Test.slnx
@@ -15,6 +15,7 @@
     <File Path="../Documentation/RevitCommand.md" />
     <File Path="../Documentation/RevitCommandAvailability.md" />
     <File Path="../Documentation/RevitContext.md" />
+    <File Path="../Documentation/RevitContextDesign.md" />
     <File Path="../Documentation/RevitEventHandler.md" />
     <File Path="../Documentation/RevitTask.md" />
     <File Path="../Documentation/RevitUpdater.md" />

--- a/Source/Scotec.Revit.Test/RevitTestApp.cs
+++ b/Source/Scotec.Revit.Test/RevitTestApp.cs
@@ -24,21 +24,7 @@ using Scotec.Revit.EventHandler;
 
 [assembly: RevitAddinIsolationContext(ContextName = "Scotec.Revit.Test")]
 
-
 namespace Scotec.Revit.Test;
-
-public class TestApplicationInitializedHandler : RevitApplicationInitializedHandler
-{
-    public TestApplicationInitializedHandler(ControlledApplication application) : base(application)
-    {
-    }
-
-    protected override void OnExecute(Application? sender, ApplicationInitializedEventArgs args)
-    {
-        base.OnExecute(sender, args);
-    }
-}
-
 
 [RevitDbApplicationIsolation(ContextName = "Scotec.Revit.Test")]
 public class DbApp : IExternalDBApplication
@@ -87,7 +73,6 @@ public class RevitTestApp : RevitApp
         {
             services.AddScoped<TestRevitDialog>();
             services.AddSingleton(new RevitTask());
-            services.AddTransient<TestApplicationInitializedHandler>();
         });
     }
 

--- a/Source/Scotec.Revit.Test/RevitTestApp.cs
+++ b/Source/Scotec.Revit.Test/RevitTestApp.cs
@@ -29,7 +29,7 @@ namespace Scotec.Revit.Test;
 
 public class TestApplicationInitializedHandler : RevitApplicationInitializedHandler
 {
-    public TestApplicationInitializedHandler(UIControlledApplication application) : base(application)
+    public TestApplicationInitializedHandler(ControlledApplication application) : base(application)
     {
     }
 
@@ -57,35 +57,12 @@ public class DbApp : IExternalDBApplication
 [RevitApplicationIsolation(ContextName = "Scotec.Revit.Test")]
 public class RevitTestApp : RevitApp
 {
-    //protected bool OnStartup(UIControlledApplication application, IConfiguration configuration)
-    //{
-    //    try
-    //    {
-    //        RevitTabManager.CreateTab(Application, "scotec");
-    //        var panel = RevitTabManager.GetPanel(Application, "Test", "scotec");
-
-    //        panel.AddItem(CreateTestButtonData());
-    //    }
-    //    catch (Exception)
-    //    {
-    //        Debugger.Launch();
-    //        return false;
-    //    }
-
-    //    return base.OnStartup(application);
-    //}
-
-    private TestApplicationInitializedHandler? _applicationInitializedHandler;
-
     [RevitApplicationStartup]
     [UsedImplicitly]
-    private bool OnStartup(UIControlledApplication application, IConfiguration configuration,
-                           TestApplicationInitializedHandler applicationInitializedHandler)
+    private bool OnStartup(UIControlledApplication application, IConfiguration configuration)
     {
         try
         {
-            _applicationInitializedHandler = applicationInitializedHandler;
-
             RevitTabManager.CreateTab(Application, "scotec");
             var panel = RevitTabManager.GetPanel(Application, "Test", "scotec");
 

--- a/Source/Scotec.Revit.Test/RevitTestCommand.cs
+++ b/Source/Scotec.Revit.Test/RevitTestCommand.cs
@@ -28,7 +28,7 @@ public class RevitTestCommand : RevitCommand
     }
 
     [RevitCommandAfterExecute]
-    protected virtual void Cleanup(ExternalCommandData commandData, ElementSet elements)
+    protected virtual void Cleanup(IGlobalRevitUiContext context, ExternalCommandData commandData, ElementSet elements)
     {
     }
 

--- a/Source/Scotec.Revit.Test/TestRevitDialog.xaml.cs
+++ b/Source/Scotec.Revit.Test/TestRevitDialog.xaml.cs
@@ -1,45 +1,45 @@
-using System;
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
-using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Scotec.Revit.Test
+namespace Scotec.Revit.Test;
+
+[SuppressMessage("ReSharper", "AsyncVoidEventHandlerMethod")]
+public partial class TestRevitDialog
 {
-    [SuppressMessage("ReSharper", "AsyncVoidEventHandlerMethod")]
-    public partial class TestRevitDialog
+    private readonly IGlobalRevitUiContext _globalContext;
+    private readonly RevitTask _revitTask;
+
+    public TestRevitDialog(IGlobalRevitUiContext globalContext, RevitTask revitTask) : base(globalContext.UiApplication)
     {
-        private readonly RevitTask _revitTask;
+        _globalContext = globalContext;
+        _revitTask = revitTask;
+        InitializeComponent();
+    }
 
-        public TestRevitDialog(IRevitUiContext context, RevitTask revitTask) : base(context.UiApplication)
+    private async void DialogButton_Click(object sender, RoutedEventArgs e)
+    {
+        var result = await _revitTask.Run(context =>
         {
-            _revitTask = revitTask;
-            InitializeComponent();
-        }
+            TaskDialog.Show("Revit Task 1", "This is a message from the Revit task!");
+            return true;
+        });
+        await _revitTask.Run(context => { TaskDialog.Show("Revit Task 2", "This is a message from the Revit task!"); });
+        await _revitTask.Run(MyRevitTask);
+    }
 
-        private async void DialogButton_Click(object sender, RoutedEventArgs e)
-        {
-            var result = await _revitTask.Run(context =>
-            {
-                TaskDialog.Show("Revit Task 1", "This is a message from the Revit task!");
-                return true;
-            });
-            await _revitTask.Run((context) =>
-            {
-                TaskDialog.Show("Revit Task 2", "This is a message from the Revit task!");
-            });
-            await _revitTask.Run(MyRevitTask);
-        }
+    private void ConfigureServices(IServiceCollection services)
+    {
+        // Register additional services if needed.
+    }
 
-        private void ConfigureServices(IServiceCollection services)
-        {
-            // Register additional services if needed.
-        }
-
-        private void MyRevitTask(IRevitUiContext context)
-        {
-            TaskDialog.Show("Revit Task 3", "This is a message from the Revit task!");
-        }
+    private void MyRevitTask(IRevitUiContext context)
+    {
+        TaskDialog.Show("Revit Task 3", "This is a message from the Revit task!");
     }
 }

--- a/Source/Scotec.Revit/EventHandler/RevitApplicationClosingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitApplicationClosingHandler.cs
@@ -21,14 +21,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]     
-public abstract class RevitApplicationClosingHandler : RevitUiPreEventHandler<ApplicationClosingEventArgs>
+public class RevitApplicationClosingHandler : RevitUiPreEventHandler<ApplicationClosingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.ApplicationClosing" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitApplicationClosingHandler(UIControlledApplication application)
+    public RevitApplicationClosingHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitApplicationInitializedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitApplicationInitializedHandler.cs
@@ -21,15 +21,15 @@ namespace Scotec.Revit.EventHandler;
 ///         The per-invocation DI scope registers <see cref="Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs" />.
 ///     </para>
 /// </remarks>
-public abstract class RevitApplicationInitializedHandler : RevitAppSingleEventHandler<ApplicationInitializedEventArgs>
+public class RevitApplicationInitializedHandler : RevitAppSingleEventHandler<ApplicationInitializedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="Autodesk.Revit.DB.Events.ApplicationInitializedEventArgs" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitApplicationInitializedHandler(UIControlledApplication application)
-        : base(application.ControlledApplication)
+    public RevitApplicationInitializedHandler(ControlledApplication application)
+        : base(application)
     {
         Subscribe();
     }

--- a/Source/Scotec.Revit/EventHandler/RevitDialogBoxShowingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDialogBoxShowingHandler.cs
@@ -22,14 +22,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI] 
-public abstract class RevitDialogBoxShowingHandler : RevitUiPreEventHandler<DialogBoxShowingEventArgs>
+public class RevitDialogBoxShowingHandler : RevitUiPreEventHandler<DialogBoxShowingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.DialogBoxShowing" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitDialogBoxShowingHandler(UIControlledApplication application)
+    public RevitDialogBoxShowingHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDisplayingOptionsDialogHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDisplayingOptionsDialogHandler.cs
@@ -22,14 +22,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDisplayingOptionsDialogHandler : RevitUiPreEventHandler<DisplayingOptionsDialogEventArgs>
+public class RevitDisplayingOptionsDialogHandler : RevitUiPreEventHandler<DisplayingOptionsDialogEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.DisplayingOptionsDialog" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitDisplayingOptionsDialogHandler(UIControlledApplication application)
+    public RevitDisplayingOptionsDialogHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentChangedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentChangedHandler.cs
@@ -60,6 +60,6 @@ public abstract class RevitDocumentChangedHandler : RevitAppSingleEventHandler<D
     protected override IRevitContext? CreateContext(Application? sender, DocumentChangedEventArgs args)
     {
         var document = args.GetDocument();
-        return document is not null ? new RevitContext(document) : null;
+        return document is not null ? new RevitContext(document) : base.CreateContext(sender, args);
     }
 }

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentChangedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentChangedHandler.cs
@@ -27,14 +27,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentChangedHandler : RevitAppSingleEventHandler<DocumentChangedEventArgs>
+public class RevitDocumentChangedHandler : RevitAppSingleEventHandler<DocumentChangedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentChanged" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentChangedHandler(ControlledApplication application)
+    public RevitDocumentChangedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();
@@ -57,7 +57,7 @@ public abstract class RevitDocumentChangedHandler : RevitAppSingleEventHandler<D
     ///     Creates an <see cref="IRevitContext" /> from the <see cref="Autodesk.Revit.DB.Events.DocumentChangedEventArgs.GetDocument" /> result
     ///     when a document is available.
     /// </remarks>
-    protected override IRevitContext? CreateContext(Application? sender, DocumentChangedEventArgs args)
+    protected sealed override IRevitContext? CreateContext(Application? sender, DocumentChangedEventArgs args)
     {
         var document = args.GetDocument();
         return document is not null ? new RevitContext(document) : base.CreateContext(sender, args);

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentClosedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentClosedHandler.cs
@@ -21,14 +21,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI] 
-public abstract class RevitDocumentClosedHandler : RevitAppPostEventHandler<DocumentClosedEventArgs>
+public class RevitDocumentClosedHandler : RevitAppPostEventHandler<DocumentClosedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentClosed" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentClosedHandler(ControlledApplication application)
+    public RevitDocumentClosedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentClosingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentClosingHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI] 
-public abstract class RevitDocumentClosingHandler : RevitAppPreDocumentEventHandler<DocumentClosingEventArgs>
+public class RevitDocumentClosingHandler : RevitAppPreDocumentEventHandler<DocumentClosingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentClosing" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentClosingHandler(ControlledApplication application)
+    public RevitDocumentClosingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentCreatedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentCreatedHandler.cs
@@ -20,13 +20,13 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentCreatedHandler : RevitAppPostDocumentEventHandler<DocumentCreatedEventArgs>
+public class RevitDocumentCreatedHandler : RevitAppPostDocumentEventHandler<DocumentCreatedEventArgs>
 {
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentCreated" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentCreatedHandler(ControlledApplication application)
+    public RevitDocumentCreatedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentCreatingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentCreatingHandler.cs
@@ -22,14 +22,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentCreatingHandler : RevitAppPreEventHandler<DocumentCreatingEventArgs>
+public class RevitDocumentCreatingHandler : RevitAppPreEventHandler<DocumentCreatingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentCreating" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentCreatingHandler(ControlledApplication application)
+    public RevitDocumentCreatingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentOpenedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentOpenedHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentOpenedHandler : RevitAppPostDocumentEventHandler<DocumentOpenedEventArgs>
+public class RevitDocumentOpenedHandler : RevitAppPostDocumentEventHandler<DocumentOpenedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentOpened" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentOpenedHandler(ControlledApplication application)
+    public RevitDocumentOpenedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentOpeningHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentOpeningHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentOpeningHandler : RevitAppPreEventHandler<DocumentOpeningEventArgs>
+public class RevitDocumentOpeningHandler : RevitAppPreEventHandler<DocumentOpeningEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentOpening" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentOpeningHandler(ControlledApplication application)
+    public RevitDocumentOpeningHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentPrintedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentPrintedHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentPrintedHandler : RevitAppPostDocumentEventHandler<DocumentPrintedEventArgs>
+public class RevitDocumentPrintedHandler : RevitAppPostDocumentEventHandler<DocumentPrintedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentPrinted" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentPrintedHandler(ControlledApplication application)
+    public RevitDocumentPrintedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentPrintingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentPrintingHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentPrintingHandler : RevitAppPreDocumentEventHandler<DocumentPrintingEventArgs>
+public class RevitDocumentPrintingHandler : RevitAppPreDocumentEventHandler<DocumentPrintingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentPrinting" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentPrintingHandler(ControlledApplication application)
+    public RevitDocumentPrintingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSavedAsHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSavedAsHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentSavedAsHandler : RevitAppPostDocumentEventHandler<DocumentSavedAsEventArgs>
+public class RevitDocumentSavedAsHandler : RevitAppPostDocumentEventHandler<DocumentSavedAsEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentSavedAs" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentSavedAsHandler(ControlledApplication application)
+    public RevitDocumentSavedAsHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSavedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSavedHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentSavedHandler : RevitAppPostDocumentEventHandler<DocumentSavedEventArgs>
+public class RevitDocumentSavedHandler : RevitAppPostDocumentEventHandler<DocumentSavedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentSaved" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentSavedHandler(ControlledApplication application)
+    public RevitDocumentSavedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSavingAsHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSavingAsHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentSavingAsHandler : RevitAppPreDocumentEventHandler<DocumentSavingAsEventArgs>
+public class RevitDocumentSavingAsHandler : RevitAppPreDocumentEventHandler<DocumentSavingAsEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentSavingAs" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentSavingAsHandler(ControlledApplication application)
+    public RevitDocumentSavingAsHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSavingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSavingHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentSavingHandler : RevitAppPreDocumentEventHandler<DocumentSavingEventArgs>
+public class RevitDocumentSavingHandler : RevitAppPreDocumentEventHandler<DocumentSavingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.DocumentSaving" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentSavingHandler(ControlledApplication application)
+    public RevitDocumentSavingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizedWithCentralHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizedWithCentralHandler.cs
@@ -50,7 +50,7 @@ public abstract class RevitDocumentSynchronizedWithCentralHandler : RevitAppPost
 
     /// <inheritdoc />
     /// <remarks>
-    ///     Creates an <see cref="IRevitContext" /> from <see cref="DocumentSynchronizedWithCentralEventArgs.Document" />
+    ///     Creates an <see cref="IRevitContext" /> from <see cref="Autodesk.Revit.DB.Events.DocumentSynchronizedWithCentralEventArgs.Document" />
     ///     when a document is available.
     /// </remarks>
     protected override IRevitContext? CreateContext(Application? sender, DocumentSynchronizedWithCentralEventArgs args)

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizedWithCentralHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizedWithCentralHandler.cs
@@ -22,7 +22,7 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentSynchronizedWithCentralHandler : RevitAppPostDocumentEventHandler<DocumentSynchronizedWithCentralEventArgs>
+public class RevitDocumentSynchronizedWithCentralHandler : RevitAppPostDocumentEventHandler<DocumentSynchronizedWithCentralEventArgs>
 {
 
     /// <summary>
@@ -30,7 +30,7 @@ public abstract class RevitDocumentSynchronizedWithCentralHandler : RevitAppPost
     ///     <see cref="ControlledApplication.DocumentSynchronizedWithCentral" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentSynchronizedWithCentralHandler(ControlledApplication application)
+    public RevitDocumentSynchronizedWithCentralHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();
@@ -53,8 +53,10 @@ public abstract class RevitDocumentSynchronizedWithCentralHandler : RevitAppPost
     ///     Creates an <see cref="IRevitContext" /> from <see cref="Autodesk.Revit.DB.Events.DocumentSynchronizedWithCentralEventArgs.Document" />
     ///     when a document is available.
     /// </remarks>
-    protected override IRevitContext? CreateContext(Application? sender, DocumentSynchronizedWithCentralEventArgs args)
+    protected sealed override IRevitContext? CreateContext(Application? sender, DocumentSynchronizedWithCentralEventArgs args)
     {
-        return args.Document is not null ? new RevitContext(args.Document) : null;
+        // Revit API: args.Document is the synchronized document.
+        // Fall back to Application when args.Document is null.
+        return args.Document is not null ? new RevitContext(args.Document) : base.CreateContext(sender, args);
     }
 }

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizingWithCentralHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizingWithCentralHandler.cs
@@ -22,7 +22,7 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitDocumentSynchronizingWithCentralHandler : RevitAppPreDocumentEventHandler<DocumentSynchronizingWithCentralEventArgs>
+public class RevitDocumentSynchronizingWithCentralHandler : RevitAppPreDocumentEventHandler<DocumentSynchronizingWithCentralEventArgs>
 {
 
     /// <summary>
@@ -30,7 +30,7 @@ public abstract class RevitDocumentSynchronizingWithCentralHandler : RevitAppPre
     ///     <see cref="ControlledApplication.DocumentSynchronizingWithCentral" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitDocumentSynchronizingWithCentralHandler(ControlledApplication application)
+    public RevitDocumentSynchronizingWithCentralHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();
@@ -53,8 +53,10 @@ public abstract class RevitDocumentSynchronizingWithCentralHandler : RevitAppPre
     ///     Creates an <see cref="IRevitContext" /> from <see cref="Autodesk.Revit.DB.Events.DocumentSynchronizingWithCentralEventArgs.Document" />
     ///     when a document is available.
     /// </remarks>
-    protected override IRevitContext? CreateContext(Application? sender, DocumentSynchronizingWithCentralEventArgs args)
+    protected sealed override IRevitContext? CreateContext(Application? sender, DocumentSynchronizingWithCentralEventArgs args)
     {
-        return args.Document is not null ? new RevitContext(args.Document) : null;
+        // Revit API: args.Document is the document being synchronized.
+        // Fall back to Application when args.Document is null.
+        return args.Document is not null ? new RevitContext(args.Document) : base.CreateContext(sender, args);
     }
 }

--- a/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizingWithCentralHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitDocumentSynchronizingWithCentralHandler.cs
@@ -50,7 +50,7 @@ public abstract class RevitDocumentSynchronizingWithCentralHandler : RevitAppPre
 
     /// <inheritdoc />
     /// <remarks>
-    ///     Creates an <see cref="IRevitContext" /> from <see cref="DocumentSynchronizingWithCentralEventArgs.Document" />
+    ///     Creates an <see cref="IRevitContext" /> from <see cref="Autodesk.Revit.DB.Events.DocumentSynchronizingWithCentralEventArgs.Document" />
     ///     when a document is available.
     /// </remarks>
     protected override IRevitContext? CreateContext(Application? sender, DocumentSynchronizingWithCentralEventArgs args)

--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Scotec.Revit.EventHandler;
 
@@ -362,7 +363,7 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
         // Delegate-subscription path: runs instead of the attribute/OnExecute path when registrations exist.
         if (_delegateRegistrations.Count > 0)
         {
-            foreach (var registration in _delegateRegistrations)
+            foreach (var registration in _delegateRegistrations.ToList())
             {
                 IServiceProvider resolvedProvider;
                 ILifetimeScope? childScope = null;

--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -9,7 +9,6 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Scotec.Revit.EventHandler;
 

--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -319,7 +319,6 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
                 ConfigureServices(services);
                 // IRevitContext is always registered.
                 // IRevitUiContext is additionally registered when the context is a UI context.
-                services.AddScoped<IRevitContext>(_ => context!);
                 builder.RegisterInstance(context!).As<IRevitContext>().OwnedByLifetimeScope();
                 if (context is IRevitUiContext uiContext)
                 {

--- a/Source/Scotec.Revit/EventHandler/RevitFabricationPartBrowserChangedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFabricationPartBrowserChangedHandler.cs
@@ -21,14 +21,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitFabricationPartBrowserChangedHandler : RevitUiSingleEventHandler<FabricationPartBrowserChangedEventArgs>
+public class RevitFabricationPartBrowserChangedHandler : RevitUiSingleEventHandler<FabricationPartBrowserChangedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.FabricationPartBrowserChanged" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitFabricationPartBrowserChangedHandler(UIControlledApplication application)
+    public RevitFabricationPartBrowserChangedHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitFailuresProcessingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFailuresProcessingHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitFailuresProcessingHandler : RevitAppSingleEventHandler<FailuresProcessingEventArgs>
+public class RevitFailuresProcessingHandler : RevitAppSingleEventHandler<FailuresProcessingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.FailuresProcessing" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitFailuresProcessingHandler(ControlledApplication application)
+    public RevitFailuresProcessingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitFileExportedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFileExportedHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI] 
-public abstract class RevitFileExportedHandler : RevitAppPostDocumentEventHandler<FileExportedEventArgs>
+public class RevitFileExportedHandler : RevitAppPostDocumentEventHandler<FileExportedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.FileExported" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitFileExportedHandler(ControlledApplication application)
+    public RevitFileExportedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitFileExportingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFileExportingHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitFileExportingHandler : RevitAppPreDocumentEventHandler<FileExportingEventArgs>
+public class RevitFileExportingHandler : RevitAppPreDocumentEventHandler<FileExportingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.FileExporting" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitFileExportingHandler(ControlledApplication application)
+    public RevitFileExportingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitFileImportedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFileImportedHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitFileImportedHandler : RevitAppPostDocumentEventHandler<FileImportedEventArgs>
+public class RevitFileImportedHandler : RevitAppPostDocumentEventHandler<FileImportedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.FileImported" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitFileImportedHandler(ControlledApplication application)
+    public RevitFileImportedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitFileImportingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFileImportingHandler.cs
@@ -23,14 +23,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitFileImportingHandler : RevitAppPreDocumentEventHandler<FileImportingEventArgs>
+public class RevitFileImportingHandler : RevitAppPreDocumentEventHandler<FileImportingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.FileImporting" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitFileImportingHandler(ControlledApplication application)
+    public RevitFileImportingHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitFormulaEditingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitFormulaEditingHandler.cs
@@ -21,14 +21,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitFormulaEditingHandler : RevitUiPreEventHandler<FormulaEditingEventArgs>
+public class RevitFormulaEditingHandler : RevitUiPreEventHandler<FormulaEditingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.FormulaEditing" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitFormulaEditingHandler(UIControlledApplication application)
+    public RevitFormulaEditingHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitIdlingHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitIdlingHandler.cs
@@ -25,14 +25,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitIdlingHandler : RevitUiPreEventHandler<IdlingEventArgs>
+public class RevitIdlingHandler : RevitUiPreEventHandler<IdlingEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.Idling" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitIdlingHandler(UIControlledApplication application)
+    public RevitIdlingHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitLinkedResourceOpenedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitLinkedResourceOpenedHandler.cs
@@ -22,14 +22,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitLinkedResourceOpenedHandler : RevitAppPostDocumentEventHandler<LinkedResourceOpenedEventArgs>
+public class RevitLinkedResourceOpenedHandler : RevitAppPostDocumentEventHandler<LinkedResourceOpenedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.LinkedResourceOpened" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitLinkedResourceOpenedHandler(ControlledApplication application)
+    public RevitLinkedResourceOpenedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitLinkedResourceOpeningHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitLinkedResourceOpeningHandler.cs
@@ -22,14 +22,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitLinkedResourceOpeningHandler : RevitAppPreEventHandler<LinkedResourceOpeningEventArgs>
+public class RevitLinkedResourceOpeningHandler : RevitAppPreEventHandler<LinkedResourceOpeningEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.LinkedResourceOpening" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitLinkedResourceOpeningHandler(ControlledApplication application)
+    public RevitLinkedResourceOpeningHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitPostDocumentEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitPostDocumentEventHandler.cs
@@ -38,7 +38,13 @@ public abstract class RevitAppPostDocumentEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitContext? CreateContext(Application? sender, TEventArgs args)
-        => args.Document is not null ? new RevitContext(args.Document) : null;
+    {
+        // Revit API: args.Document is preferred when available (e.g. DocumentSaved, DocumentClosed before GC).
+        // Fall back to Application when args.Document is null (e.g. DocumentClosed after the document is destroyed).
+        if (args.Document is { } document)
+            return new RevitContext(document);
+        return sender is not null ? new RevitContext(sender) : null;
+    }
 }
 
 /// <summary>
@@ -60,5 +66,5 @@ public abstract class RevitUiPostDocumentEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitUiContext? CreateContext(UIApplication? sender, TEventArgs args)
-        => sender?.ActiveUIDocument is not null ? new RevitUiContext(sender) : null;
+        => sender is not null ? new RevitUiContext(sender) : null;
 }

--- a/Source/Scotec.Revit/EventHandler/RevitPostEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitPostEventHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2026 Olaf Meyer
+ï»¿// Copyright (c) 2023 - 2026 Olaf Meyer
 // Copyright (c) 2023 - 2026 scotec Software Solutions AB, www.scotec.com
 // This file is licensed to you under the MIT license.
 
@@ -37,8 +37,8 @@ public abstract class RevitAppPostEventHandler<TEventArgs>
     protected ControlledApplication Application { get; }
 
     /// <inheritdoc />
-    /// <remarks>Returns <c>null</c> — a bare <see cref="Application" /> sender carries no context at this level.</remarks>
-    protected override IRevitContext? CreateContext(Application? sender, TEventArgs args) => null;
+    protected override IRevitContext? CreateContext(Application? sender, TEventArgs args)
+        => sender is not null ? new RevitContext(sender) : null;
 }
 
 /// <summary>
@@ -60,5 +60,5 @@ public abstract class RevitUiPostEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitUiContext? CreateContext(UIApplication? sender, TEventArgs args)
-        => sender?.ActiveUIDocument is not null ? new RevitUiContext(sender) : null;
+        => sender is not null ? new RevitUiContext(sender) : null;
 }

--- a/Source/Scotec.Revit/EventHandler/RevitPreDocumentEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitPreDocumentEventHandler.cs
@@ -38,7 +38,13 @@ public abstract class RevitAppPreDocumentEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitContext? CreateContext(Application? sender, TEventArgs args)
-        => args.Document is not null ? new RevitContext(args.Document) : null;
+    {
+        // Revit API: args.Document is preferred when available (e.g. DocumentOpening before it is set as ActiveDocument).
+        // Fall back to Application when args.Document is null (e.g. DocumentCreating before the document exists).
+        if (args.Document is { } document)
+            return new RevitContext(document);
+        return sender is not null ? new RevitContext(sender) : null;
+    }
 }
 
 /// <summary>
@@ -60,5 +66,5 @@ public abstract class RevitUiPreDocumentEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitUiContext? CreateContext(UIApplication? sender, TEventArgs args)
-        => sender?.ActiveUIDocument is not null ? new RevitUiContext(sender) : null;
+        => sender is not null ? new RevitUiContext(sender) : null;
 }

--- a/Source/Scotec.Revit/EventHandler/RevitPreEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitPreEventHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2026 Olaf Meyer
+ï»¿// Copyright (c) 2023 - 2026 Olaf Meyer
 // Copyright (c) 2023 - 2026 scotec Software Solutions AB, www.scotec.com
 // This file is licensed to you under the MIT license.
 
@@ -60,8 +60,8 @@ public abstract class RevitAppPreEventHandler<TEventArgs>
     protected ControlledApplication Application { get; }
 
     /// <inheritdoc />
-    /// <remarks>Returns <c>null</c> — a bare <see cref="Application" /> sender carries no context at this level.</remarks>
-    protected override IRevitContext? CreateContext(Application? sender, TEventArgs args) => null;
+    protected override IRevitContext? CreateContext(Application? sender, TEventArgs args)
+        => sender is not null ? new RevitContext(sender) : null;
 }
 
 /// <summary>
@@ -83,5 +83,5 @@ public abstract class RevitUiPreEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitUiContext? CreateContext(UIApplication? sender, TEventArgs args)
-        => sender?.ActiveUIDocument is not null ? new RevitUiContext(sender) : null;
+        => sender is not null ? new RevitUiContext(sender) : null;
 }

--- a/Source/Scotec.Revit/EventHandler/RevitProgressChangedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitProgressChangedHandler.cs
@@ -26,14 +26,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitProgressChangedHandler : RevitAppSingleEventHandler<ProgressChangedEventArgs>
+public class RevitProgressChangedHandler : RevitAppSingleEventHandler<ProgressChangedEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="ControlledApplication.ProgressChanged" />.
     /// </summary>
     /// <param name="application">The Revit controlled application.</param>
-    protected RevitProgressChangedHandler(ControlledApplication application)
+    public RevitProgressChangedHandler(ControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitSingleEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitSingleEventHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2026 Olaf Meyer
+ï»¿// Copyright (c) 2023 - 2026 Olaf Meyer
 // Copyright (c) 2023 - 2026 scotec Software Solutions AB, www.scotec.com
 // This file is licensed to you under the MIT license.
 
@@ -37,8 +37,8 @@ public abstract class RevitAppSingleEventHandler<TEventArgs>
     protected ControlledApplication Application { get; }
 
     /// <inheritdoc />
-    /// <remarks>Returns <c>null</c> — a bare <see cref="Application" /> sender carries no context at this level.</remarks>
-    protected override IRevitContext? CreateContext(Application? sender, TEventArgs args) => null;
+    protected override IRevitContext? CreateContext(Application? sender, TEventArgs args)
+        => sender is not null ? new RevitContext(sender) : null;
 }
 
 /// <summary>
@@ -60,5 +60,5 @@ public abstract class RevitUiSingleEventHandler<TEventArgs>
 
     /// <inheritdoc />
     protected override IRevitUiContext? CreateContext(UIApplication? sender, TEventArgs args)
-        => sender?.ActiveUIDocument is not null ? new RevitUiContext(sender) : null;
+        => sender is not null ? new RevitUiContext(sender) : null;
 }

--- a/Source/Scotec.Revit/EventHandler/RevitTransferredProjectStandardsHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitTransferredProjectStandardsHandler.cs
@@ -21,14 +21,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitTransferredProjectStandardsHandler : RevitUiSingleEventHandler<TransferredProjectStandardsEventArgs>
+public class RevitTransferredProjectStandardsHandler : RevitUiSingleEventHandler<TransferredProjectStandardsEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.TransferredProjectStandards" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitTransferredProjectStandardsHandler(UIControlledApplication application)
+    public RevitTransferredProjectStandardsHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitTransferringProjectStandardsHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitTransferringProjectStandardsHandler.cs
@@ -21,14 +21,14 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitTransferringProjectStandardsHandler : RevitUiPreDocumentEventHandler<TransferringProjectStandardsEventArgs>
+public class RevitTransferringProjectStandardsHandler : RevitUiPreDocumentEventHandler<TransferringProjectStandardsEventArgs>
 {
 
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.TransferringProjectStandards" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitTransferringProjectStandardsHandler(UIControlledApplication application)
+    public RevitTransferringProjectStandardsHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/EventHandler/RevitViewActivatedHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitViewActivatedHandler.cs
@@ -21,13 +21,13 @@ namespace Scotec.Revit.EventHandler;
 ///     </para>
 /// </remarks>
 [PublicAPI]
-public abstract class RevitViewActivatedHandler : RevitUiPostDocumentEventHandler<ViewActivatedEventArgs>
+public class RevitViewActivatedHandler : RevitUiPostDocumentEventHandler<ViewActivatedEventArgs>
 {
     /// <summary>
     ///     Initializes a new instance and subscribes to <see cref="UIControlledApplication.ViewActivated" />.
     /// </summary>
     /// <param name="application">The Revit UI controlled application.</param>
-    protected RevitViewActivatedHandler(UIControlledApplication application)
+    public RevitViewActivatedHandler(UIControlledApplication application)
         : base(application)
     {
         Subscribe();

--- a/Source/Scotec.Revit/GlobalRevitContext.cs
+++ b/Source/Scotec.Revit/GlobalRevitContext.cs
@@ -1,0 +1,130 @@
+﻿// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Scotec.Revit.EventHandler;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     A long-lived, application-scoped implementation of <see cref="IGlobalRevitContext" /> that
+///     wraps the Revit <see cref="Autodesk.Revit.ApplicationServices.Application" /> for use
+///     as a singleton outside individual event handler or command scopes.
+/// </summary>
+/// <remarks>
+///     Suitable for DB-level add-ins (<see cref="RevitDbApp" />) that do not have a
+///     <see cref="UIApplication" />. For UI add-ins use <see cref="GlobalRevitUiContext" />.
+///     <para>
+///         <see cref="Application" /> becomes available after Revit fires
+///         <c>ApplicationInitialized</c>. Accessing it before that event will throw.
+///     </para>
+///     <para>
+///         Unlike the per-invocation <see cref="RevitContext" />, this singleton does not carry
+///         a document reference. Use <see cref="IGlobalRevitUiContext.UiDocument" /> or
+///         <see cref="IGlobalRevitUiContext.ActiveDocument" /> from the UI context instead.
+///     </para>
+/// </remarks>
+public class GlobalRevitContext : IGlobalRevitContext
+{
+    /// <summary>
+    ///     Initializes a new instance. Subscribes to <c>ApplicationInitialized</c> once
+    ///     to capture the <see cref="Application" /> reference, then unsubscribes.
+    /// </summary>
+    /// <param name="application">The Revit controlled application provided at add-in startup.</param>
+    /// <exception cref="System.ArgumentNullException">
+    ///     Thrown when <paramref name="application" /> is <c>null</c>.
+    /// </exception>
+    public GlobalRevitContext(ControlledApplication application)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        Application = null!; // Will be set in the handler before any access is possible.
+
+        var initializedHandler = new RevitApplicationInitializedHandler(application);
+        IDisposable initializedHandlerHandle = null!;
+        initializedHandlerHandle = initializedHandler.AddHandler(context =>
+        {
+            Application = context.Application;
+            initializedHandlerHandle.Dispose();
+        });
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.ApplicationServices.Application" />
+    ///     is no longer valid.
+    /// </exception>
+    public Application Application
+    {
+        get
+        {
+            // Revit API: Application.IsValidObject must be checked before access after potential application lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit application is no longer valid.");
+            return field;
+        }
+        protected set;
+    }
+}
+
+/// <summary>
+///     A long-lived, application-scoped implementation of <see cref="IGlobalRevitUiContext" /> that
+///     wraps the Revit <see cref="UIApplication" /> for use as a singleton outside individual event
+///     handler or command scopes.
+/// </summary>
+/// <remarks>
+///     Use this for UI add-ins derived from <see cref="RevitApp" />. <see cref="UiDocument" />,
+///     <see cref="ActiveDocument" />, and <see cref="ActiveView" /> reflect the state at the moment
+///     of access and return <c>null</c> when no document is currently open.
+/// </remarks>
+public class GlobalRevitUiContext : GlobalRevitContext, IGlobalRevitUiContext
+{
+    /// <summary>
+    ///     Initializes a new instance with the given Revit UI controlled application.
+    /// </summary>
+    /// <param name="uiControlledApplication">The Revit UI controlled application provided at add-in startup.</param>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="uiControlledApplication" /> is <c>null</c>.
+    /// </exception>
+    public GlobalRevitUiContext(UIControlledApplication uiControlledApplication)
+        : base((uiControlledApplication ?? throw new ArgumentNullException(nameof(uiControlledApplication))).ControlledApplication)
+    {
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the underlying <see cref="UIApplication" /> is no longer valid.
+    /// </exception>
+    public UIApplication UiApplication
+    {
+        get
+        {
+            // Revit API: UIApplication wraps the Application; construct from the validated Application field.
+            var uiApp = new UIApplication(Application);
+            if (!uiApp.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
+            return uiApp;
+        }
+    }
+
+    /// <inheritdoc />
+    public UIDocument? UiDocument => UiApplication.ActiveUIDocument;
+
+    /// <inheritdoc />
+    public Document? ActiveDocument => UiDocument?.Document;
+
+    /// <inheritdoc />
+    public View? ActiveView
+    {
+        get
+        {
+            var view = UiDocument?.ActiveView;
+            // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
+            if (view is not null && !view.IsValidObject)
+                throw new InvalidOperationException("The active Revit view is no longer valid.");
+            return view;
+        }
+    }
+}
+

--- a/Source/Scotec.Revit/GlobalRevitContext.cs
+++ b/Source/Scotec.Revit/GlobalRevitContext.cs
@@ -4,8 +4,6 @@
 
 using System;
 using Autodesk.Revit.ApplicationServices;
-using Autodesk.Revit.DB;
-using Autodesk.Revit.UI;
 using Scotec.Revit.EventHandler;
 
 namespace Scotec.Revit;
@@ -68,63 +66,3 @@ public class GlobalRevitContext : IGlobalRevitContext
         protected set;
     }
 }
-
-/// <summary>
-///     A long-lived, application-scoped implementation of <see cref="IGlobalRevitUiContext" /> that
-///     wraps the Revit <see cref="Autodesk.Revit.UI.UIApplication" /> for use as a singleton outside individual event
-///     handler or command scopes.
-/// </summary>
-/// <remarks>
-///     Use this for UI add-ins derived from <see cref="RevitApp" />. <see cref="UiDocument" />,
-///     <see cref="ActiveDocument" />, and <see cref="ActiveView" /> reflect the state at the moment
-///     of access and return <c>null</c> when no document is currently open.
-/// </remarks>
-public class GlobalRevitUiContext : GlobalRevitContext, IGlobalRevitUiContext
-{
-    /// <summary>
-    ///     Initializes a new instance with the given Revit UI controlled application.
-    /// </summary>
-    /// <param name="uiControlledApplication">The Revit UI controlled application provided at add-in startup.</param>
-    /// <exception cref="ArgumentNullException">
-    ///     Thrown when <paramref name="uiControlledApplication" /> is <c>null</c>.
-    /// </exception>
-    public GlobalRevitUiContext(UIControlledApplication uiControlledApplication)
-        : base((uiControlledApplication ?? throw new ArgumentNullException(nameof(uiControlledApplication))).ControlledApplication)
-    {
-    }
-
-    /// <inheritdoc />
-    /// <exception cref="InvalidOperationException">
-    ///     Thrown when the underlying <see cref="Autodesk.Revit.UI.UIApplication" /> is no longer valid.
-    /// </exception>
-    public UIApplication UiApplication
-    {
-        get
-        {
-            // Revit API: UIApplication wraps the Application; construct from the validated Application field.
-            var uiApp = new UIApplication(Application);
-            if (!uiApp.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
-            return uiApp;
-        }
-    }
-
-    /// <inheritdoc />
-    public UIDocument? UiDocument => UiApplication.ActiveUIDocument;
-
-    /// <inheritdoc />
-    public Document? ActiveDocument => UiDocument?.Document;
-
-    /// <inheritdoc />
-    public View? ActiveView
-    {
-        get
-        {
-            var view = UiDocument?.ActiveView;
-            // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
-            if (view is not null && !view.IsValidObject)
-                throw new InvalidOperationException("The active Revit view is no longer valid.");
-            return view;
-        }
-    }
-}
-

--- a/Source/Scotec.Revit/GlobalRevitContext.cs
+++ b/Source/Scotec.Revit/GlobalRevitContext.cs
@@ -17,9 +17,9 @@ namespace Scotec.Revit;
 /// </summary>
 /// <remarks>
 ///     Suitable for DB-level add-ins (<see cref="RevitDbApp" />) that do not have a
-///     <see cref="UIApplication" />. For UI add-ins use <see cref="GlobalRevitUiContext" />.
+///     <see cref="Autodesk.Revit.UI.UIApplication" />. For UI add-ins use <see cref="GlobalRevitUiContext" />.
 ///     <para>
-///         <see cref="Application" /> becomes available after Revit fires
+///         <see cref="GlobalRevitContext.Application" /> becomes available after Revit fires
 ///         <c>ApplicationInitialized</c>. Accessing it before that event will throw.
 ///     </para>
 ///     <para>
@@ -32,7 +32,7 @@ public class GlobalRevitContext : IGlobalRevitContext
 {
     /// <summary>
     ///     Initializes a new instance. Subscribes to <c>ApplicationInitialized</c> once
-    ///     to capture the <see cref="Application" /> reference, then unsubscribes.
+    ///     to capture the <see cref="GlobalRevitContext.Application" /> reference, then unsubscribes.
     /// </summary>
     /// <param name="application">The Revit controlled application provided at add-in startup.</param>
     /// <exception cref="System.ArgumentNullException">
@@ -44,10 +44,10 @@ public class GlobalRevitContext : IGlobalRevitContext
         Application = null!; // Will be set in the handler before any access is possible.
 
         var initializedHandler = new RevitApplicationInitializedHandler(application);
-        IDisposable initializedHandlerHandle = null!;
-        initializedHandlerHandle = initializedHandler.AddHandler(context =>
+        var initializedHandlerHandle = new SerialDisposable();
+        initializedHandlerHandle.Disposable = initializedHandler.AddHandler(context =>
         {
-            Application = context.Application;
+            Application = context.Application;  
             initializedHandlerHandle.Dispose();
         });
     }
@@ -71,7 +71,7 @@ public class GlobalRevitContext : IGlobalRevitContext
 
 /// <summary>
 ///     A long-lived, application-scoped implementation of <see cref="IGlobalRevitUiContext" /> that
-///     wraps the Revit <see cref="UIApplication" /> for use as a singleton outside individual event
+///     wraps the Revit <see cref="Autodesk.Revit.UI.UIApplication" /> for use as a singleton outside individual event
 ///     handler or command scopes.
 /// </summary>
 /// <remarks>
@@ -95,7 +95,7 @@ public class GlobalRevitUiContext : GlobalRevitContext, IGlobalRevitUiContext
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">
-    ///     Thrown when the underlying <see cref="UIApplication" /> is no longer valid.
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.UI.UIApplication" /> is no longer valid.
     /// </exception>
     public UIApplication UiApplication
     {

--- a/Source/Scotec.Revit/GlobalRevitUiContext.cs
+++ b/Source/Scotec.Revit/GlobalRevitUiContext.cs
@@ -1,0 +1,68 @@
+﻿// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     A long-lived, application-scoped implementation of <see cref="IGlobalRevitUiContext" /> that
+///     wraps the Revit <see cref="Autodesk.Revit.UI.UIApplication" /> for use as a singleton outside individual event
+///     handler or command scopes.
+/// </summary>
+/// <remarks>
+///     Use this for UI add-ins derived from <see cref="RevitApp" />. <see cref="UiDocument" />,
+///     <see cref="ActiveDocument" />, and <see cref="ActiveView" /> reflect the state at the moment
+///     of access and return <c>null</c> when no document is currently open.
+/// </remarks>
+public class GlobalRevitUiContext : GlobalRevitContext, IGlobalRevitUiContext
+{
+    /// <summary>
+    ///     Initializes a new instance with the given Revit UI controlled application.
+    /// </summary>
+    /// <param name="uiControlledApplication">The Revit UI controlled application provided at add-in startup.</param>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="uiControlledApplication" /> is <c>null</c>.
+    /// </exception>
+    public GlobalRevitUiContext(UIControlledApplication uiControlledApplication)
+        : base((uiControlledApplication ?? throw new ArgumentNullException(nameof(uiControlledApplication))).ControlledApplication)
+    {
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.UI.UIApplication" /> is no longer valid.
+    /// </exception>
+    public UIApplication UiApplication
+    {
+        get
+        {
+            // Revit API: UIApplication wraps the Application; construct from the validated Application field.
+            var uiApp = new UIApplication(Application);
+            if (!uiApp.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
+            return uiApp;
+        }
+    }
+
+    /// <inheritdoc />
+    public UIDocument? UiDocument => UiApplication.ActiveUIDocument;
+
+    /// <inheritdoc />
+    public Document? ActiveDocument => UiDocument?.Document;
+
+    /// <inheritdoc />
+    public View? ActiveView
+    {
+        get
+        {
+            var view = UiDocument?.ActiveView;
+            // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
+            if (view is not null && !view.IsValidObject)
+                throw new InvalidOperationException("The active Revit view is no longer valid.");
+            return view;
+        }
+    }
+}

--- a/Source/Scotec.Revit/IGlobalRevitContext.cs
+++ b/Source/Scotec.Revit/IGlobalRevitContext.cs
@@ -1,0 +1,30 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using Autodesk.Revit.ApplicationServices;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Provides application-lifetime access to the Revit
+///     <see cref="Autodesk.Revit.ApplicationServices.Application" /> for use outside
+///     individual event handler or command scopes (e.g. as a singleton in the DI container).
+/// </summary>
+/// <remarks>
+///     Unlike <see cref="IRevitContext" />, which is only available inside a scoped Revit event or
+///     command invocation, this interface is registered as a singleton in the root DI container
+///     and is always resolvable regardless of whether a Revit callback is currently executing.
+/// </remarks>
+public interface IGlobalRevitContext
+{
+    /// <summary>
+    ///     Gets the Revit application.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.ApplicationServices.Application" />
+    ///     is no longer valid.
+    /// </exception>
+    Application Application { get; }
+}

--- a/Source/Scotec.Revit/IGlobalRevitUiContext.cs
+++ b/Source/Scotec.Revit/IGlobalRevitUiContext.cs
@@ -1,0 +1,55 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Extends <see cref="IGlobalRevitContext" /> with application-lifetime UI-layer access for
+///     <see cref="RevitApp" />-based add-ins.
+/// </summary>
+/// <remarks>
+///     Registered as a singleton in the root DI container for add-ins derived from <see cref="RevitApp" />.
+///     <see cref="UiDocument" />, <see cref="ActiveDocument" />, and <see cref="ActiveView" /> reflect
+///     the state at the moment of access and return <c>null</c> when no document is currently open.
+/// </remarks>
+public interface IGlobalRevitUiContext : IGlobalRevitContext
+{
+    /// <summary>
+    ///     Gets the Revit UI application.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.UI.UIApplication" /> is no longer valid.
+    /// </exception>
+    UIApplication UiApplication { get; }
+
+    /// <summary>
+    ///     Gets the currently active Revit UI document, or <c>null</c> when no document is open.
+    /// </summary>
+    UIDocument? UiDocument { get; }
+
+    /// <summary>
+    ///     Gets the document associated with the currently active UI document,
+    ///     or <c>null</c> when no document is open.
+    /// </summary>
+    /// <remarks>
+    ///     Equivalent to <c>UiDocument?.Document</c>. Prefer this over accessing
+    ///     <see cref="IRevitContext.Document" /> which is not available on the global context.
+    /// </remarks>
+    Document? ActiveDocument { get; }
+
+    /// <summary>
+    ///     Gets the view currently active in <see cref="UiDocument" />,
+    ///     or <c>null</c> when no document is open.
+    /// </summary>
+    /// <remarks>
+    ///     Reflects the view active at the moment of access rather than at any earlier point.
+    /// </remarks>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the returned <see cref="View" /> reference is no longer valid.
+    /// </exception>
+    View? ActiveView { get; }
+}

--- a/Source/Scotec.Revit/IGlobalRevitUiContext.cs
+++ b/Source/Scotec.Revit/IGlobalRevitUiContext.cs
@@ -15,6 +15,11 @@ namespace Scotec.Revit;
 ///     Registered as a singleton in the root DI container for add-ins derived from <see cref="RevitApp" />.
 ///     <see cref="UiDocument" />, <see cref="ActiveDocument" />, and <see cref="ActiveView" /> reflect
 ///     the state at the moment of access and return <c>null</c> when no document is currently open.
+///     <para>
+///         This interface is intended for lightweight, read-only checks such as ribbon state or command
+///         availability. Document data should be accessed inside a scoped <see cref="IRevitContext" />
+///         rather than through this singleton.
+///     </para>
 /// </remarks>
 public interface IGlobalRevitUiContext : IGlobalRevitContext
 {
@@ -35,10 +40,6 @@ public interface IGlobalRevitUiContext : IGlobalRevitContext
     ///     Gets the document associated with the currently active UI document,
     ///     or <c>null</c> when no document is open.
     /// </summary>
-    /// <remarks>
-    ///     Equivalent to <c>UiDocument?.Document</c>. Prefer this over accessing
-    ///     <see cref="IRevitContext.Document" /> which is not available on the global context.
-    /// </remarks>
     Document? ActiveDocument { get; }
 
     /// <summary>
@@ -49,7 +50,7 @@ public interface IGlobalRevitUiContext : IGlobalRevitContext
     ///     Reflects the view active at the moment of access rather than at any earlier point.
     /// </remarks>
     /// <exception cref="System.InvalidOperationException">
-    ///     Thrown when the returned <see cref="View" /> reference is no longer valid.
+    ///     Thrown when the returned <see cref="Autodesk.Revit.DB.View" /> reference is no longer valid.
     /// </exception>
     View? ActiveView { get; }
 }

--- a/Source/Scotec.Revit/IRevitContext.cs
+++ b/Source/Scotec.Revit/IRevitContext.cs
@@ -2,21 +2,41 @@
 // Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
 // This file is licensed to you under the MIT license.
 
+using System;
 using Autodesk.Revit.ApplicationServices;
 using Autodesk.Revit.DB;
 
 namespace Scotec.Revit;
 
+/// <summary>
+///     Provides access to the Revit <see cref="Autodesk.Revit.ApplicationServices.Application" />
+///     and the current <see cref="Autodesk.Revit.DB.Document" /> within the scope of a
+///     Revit event handler or external command.
+/// </summary>
 public interface IRevitContext
 {
     /// <summary>
     ///     Gets the current Revit application.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the underlying <see cref="Autodesk.Revit.ApplicationServices.Application" />
+    ///     is no longer valid.
+    /// </exception>
     Application Application { get; }
 
     /// <summary>
     ///     Gets the current Revit document, or <c>null</c> when no document is available
     ///     (e.g. commands executed without an open document).
     /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the document reference is non-null and the underlying
+    ///     <see cref="Autodesk.Revit.DB.Document" /> is no longer valid.
+    /// </exception>
     Document? Document { get; }
 }

--- a/Source/Scotec.Revit/IRevitContext.cs
+++ b/Source/Scotec.Revit/IRevitContext.cs
@@ -15,7 +15,8 @@ public interface IRevitContext
     Application Application { get; }
 
     /// <summary>
-    ///     Gets the current Revit document.
+    ///     Gets the current Revit document, or throws <see cref="System.InvalidOperationException" />
+    ///     when no document is available (e.g. commands executed without an open document).
     /// </summary>
-    Document Document { get; }
+    Document? Document { get; }
 }

--- a/Source/Scotec.Revit/IRevitContext.cs
+++ b/Source/Scotec.Revit/IRevitContext.cs
@@ -15,8 +15,8 @@ public interface IRevitContext
     Application Application { get; }
 
     /// <summary>
-    ///     Gets the current Revit document, or throws <see cref="System.InvalidOperationException" />
-    ///     when no document is available (e.g. commands executed without an open document).
+    ///     Gets the current Revit document, or <c>null</c> when no document is available
+    ///     (e.g. commands executed without an open document).
     /// </summary>
     Document? Document { get; }
 }

--- a/Source/Scotec.Revit/IRevitUiContext.cs
+++ b/Source/Scotec.Revit/IRevitUiContext.cs
@@ -15,12 +15,12 @@ public interface IRevitUiContext : IRevitContext
     UIApplication UiApplication { get; }
 
     /// <summary>
-    ///     Gets the current Revit UI document.
+    ///     Gets the current Revit UI document, or <c>null</c> when no document is open.
     /// </summary>
-    UIDocument UiDocument { get; }
+    UIDocument? UiDocument { get; }
 
     /// <summary>
-    ///     Gets the active view in the current Revit UI document.
+    ///     Gets the active view in the current Revit UI document, or <c>null</c> when no document is open.
     /// </summary>
-    View ActiveView { get; }
+    View? ActiveView { get; }
 }

--- a/Source/Scotec.Revit/IRevitUiContext.cs
+++ b/Source/Scotec.Revit/IRevitUiContext.cs
@@ -7,20 +7,51 @@ using Autodesk.Revit.UI;
 
 namespace Scotec.Revit;
 
+/// <summary>
+///     Extends <see cref="IRevitContext" /> with UI-layer access: <see cref="UIApplication" />,
+///     <see cref="IRevitUiContext.UiDocument" />, and <see cref="IRevitUiContext.ActiveView" />.
+/// </summary>
+/// <remarks>
+///     Implemented within the scope of a Revit UI event handler or external command where
+///     a <see cref="UIApplication" /> is available. When no document is open,
+///     <see cref="IRevitUiContext.UiDocument" /> and <see cref="IRevitUiContext.ActiveView" />
+///     return <c>null</c>.
+/// </remarks>
 public interface IRevitUiContext : IRevitContext
 {
     /// <summary>
     ///     Gets the current Revit UI application.
     /// </summary>
+    /// <exception cref="System.ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the underlying <see cref="UIApplication" /> is no longer valid.
+    /// </exception>
     UIApplication UiApplication { get; }
 
     /// <summary>
     ///     Gets the current Revit UI document, or <c>null</c> when no document is open.
     /// </summary>
+    /// <exception cref="System.ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    ///     Thrown when the UI document reference is non-null and the underlying
+    ///     <see cref="UIDocument" /> is no longer valid.
+    /// </exception>
     UIDocument? UiDocument { get; }
 
     /// <summary>
-    ///     Gets the active view in the current Revit UI document, or <c>null</c> when no document is open.
+    ///     Gets the view currently active in <see cref="IRevitUiContext.UiDocument" />,
+    ///     or <c>null</c> when no document is open.
     /// </summary>
+    /// <remarks>
+    ///     Reflects the view active at the moment of access rather than at handler invocation start.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the returned <see cref="View" /> reference is non-null and the underlying
+    ///     <see cref="View" /> is no longer valid.
+    /// </exception>
     View? ActiveView { get; }
 }

--- a/Source/Scotec.Revit/RevitApp.cs
+++ b/Source/Scotec.Revit/RevitApp.cs
@@ -13,7 +13,7 @@ namespace Scotec.Revit;
 
 /// <summary>
 ///     Represents an abstract base class for creating Revit external applications.
-///     This class provides integration with Revit's <see cref="UIControlledApplication" /> and supports
+///     This class provides integration with Revit's <see cref="Autodesk.Revit.UI.UIControlledApplication" /> and supports
 ///     advanced features such as dependency injection and service configuration.
 /// </summary>
 /// <remarks>
@@ -25,10 +25,10 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
     private static readonly Type[] UiControlledApplicationSignature = [typeof(UIControlledApplication)];
 
     /// <summary>
-    ///     Gets the <see cref="UIControlledApplication" /> instance associated with the Revit application.
+    ///     Gets the <see cref="Autodesk.Revit.UI.UIControlledApplication" /> instance associated with the Revit application.
     /// </summary>
     /// <value>
-    ///     The <see cref="UIControlledApplication" /> instance that provides access to Revit's controlled application
+    ///     The <see cref="Autodesk.Revit.UI.UIControlledApplication" /> instance that provides access to Revit's controlled application
     ///     features.
     /// </value>
     /// <remarks>
@@ -47,16 +47,16 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
     ///     Invoked by Revit during the startup of the external application.
     /// </summary>
     /// <param name="application">
-    ///     The <see cref="UIControlledApplication" /> instance provided by Revit.
+    ///     The <see cref="Autodesk.Revit.UI.UIControlledApplication" /> instance provided by Revit.
     /// </param>
     /// <returns>
-    ///     A <see cref="Result" /> indicating the success or failure of the startup process.
+    ///     A <see cref="Autodesk.Revit.UI.Result" /> indicating the success or failure of the startup process.
     /// </returns>
     /// <remarks>
-    ///     This method initializes the <see cref="Application" /> property and delegates the startup logic
-    ///     to the <see cref="RevitAppBase.OnStartup(Autodesk.Revit.DB.AddInId)" /> method. If the base class startup process
-    ///     completes successfully, it returns <see cref="Result.Succeeded" />; otherwise, it returns
-    ///     <see cref="Result.Failed" />.
+    ///     This method initializes the <see cref="RevitApp.Application" /> property and delegates the startup logic
+    ///     to the <see cref="RevitAppBase.StartupCore(Autodesk.Revit.DB.AddInId)" /> method. If the base class startup process
+    ///     completes successfully, it returns <see cref="Autodesk.Revit.UI.Result.Succeeded" />; otherwise, it returns
+    ///     <see cref="Autodesk.Revit.UI.Result.Failed" />.
     /// </remarks>
     /// <exception cref="Exception">
     ///     Thrown if an error occurs during the startup process.
@@ -82,7 +82,7 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
     ///     <see cref="Autodesk.Revit.UI.Result.Failed" />.
     /// </returns>
     /// <remarks>
-    ///     This method delegates the shutdown process to the <see cref="RevitAppBase.OnShutdown(ControlledApplication)" />
+    ///     This method delegates the shutdown process to the <see cref="RevitApp.OnShutdown(Autodesk.Revit.UI.UIControlledApplication)" />
     ///     method
     ///     and performs additional cleanup tasks specific to the Revit external application.
     /// </remarks>
@@ -98,14 +98,14 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
     ///     Executes tasks when Revit starts.
     /// </summary>
     /// <param name="application">
-    ///     The <see cref="UIControlledApplication" /> instance provided by Revit.
+    ///     The <see cref="Autodesk.Revit.UI.UIControlledApplication" /> instance provided by Revit.
     /// </param>
     /// <returns>
     ///     A boolean value indicating whether the startup process was successful.
     /// </returns>
     /// <remarks>
     ///     Override this method in a derived class to implement custom startup logic with access to the
-    ///     Revit <see cref="UIControlledApplication" />, or declare a custom <c>OnStartup</c> method marked with
+    ///     Revit <see cref="Autodesk.Revit.UI.UIControlledApplication" />, or declare a custom <c>OnStartup</c> method marked with
     ///     <see cref="RevitApplicationStartupAttribute" /> with additional DI-resolved parameters.
     /// </remarks>
     [UsedImplicitly]
@@ -118,14 +118,14 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
     ///     Executes tasks during the shutdown process of the Revit application.
     /// </summary>
     /// <param name="application">
-    ///     The <see cref="UIControlledApplication" /> instance provided by Revit.
+    ///     The <see cref="Autodesk.Revit.UI.UIControlledApplication" /> instance provided by Revit.
     /// </param>
     /// <returns>
     ///     A boolean value indicating the success or failure of the shutdown process.
     /// </returns>
     /// <remarks>
     ///     Override this method in a derived class to define custom shutdown behavior with access to the
-    ///     Revit <see cref="UIControlledApplication" />, or declare a custom <c>OnShutdown</c> method marked with
+    ///     Revit <see cref="Autodesk.Revit.UI.UIControlledApplication" />, or declare a custom <c>OnShutdown</c> method marked with
     ///     <see cref="RevitApplicationShutdownAttribute" /> with additional DI-resolved parameters.
     /// </remarks>
     [UsedImplicitly]
@@ -143,7 +143,7 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
     /// <remarks>
     ///     This method is invoked during the initialization of the Revit application to configure
     ///     dependency injection and service registration. It adds essential Revit-specific services,
-    ///     such as the <see cref="UIControlledApplication" />, the active add-in ID, and the controlled application,
+    ///     such as the <see cref="Autodesk.Revit.UI.UIControlledApplication" />, the active add-in ID, and the controlled application,
     ///     to the service collection.
     /// </remarks>
     protected override void OnConfigure(IHostBuilder builder)

--- a/Source/Scotec.Revit/RevitApp.cs
+++ b/Source/Scotec.Revit/RevitApp.cs
@@ -160,6 +160,7 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
             services.AddSingleton(Application);
             services.AddSingleton(Application.ActiveAddInId);
             services.AddSingleton(Application.ControlledApplication);
+            services.AddGlobalRevitContext(Application);
         });
     }
 }

--- a/Source/Scotec.Revit/RevitAppBase.cs
+++ b/Source/Scotec.Revit/RevitAppBase.cs
@@ -77,7 +77,7 @@ public abstract class RevitAppBase
     /// <remarks>
     ///     This property must be <c>static</c> because Revit instantiates types such as
     ///     <see cref="RevitCommand" />, <see cref="RevitCommandAvailability" />, and
-    ///     <see cref="RevitEventHandler{TEventArgs}" /> directly, without any knowledge of DI.
+    ///     <see cref="RevitEventHandler{TSender, TEventArgs, TContext}" /> directly, without any knowledge of DI.
     ///     A static entry point is therefore the only way those types can obtain the service provider
     ///     at runtime without requiring Revit to participate in object construction.
     /// </remarks>
@@ -177,7 +177,7 @@ public abstract class RevitAppBase
     ///     A boolean value indicating the success or failure of the shutdown process.
     /// </returns>
     /// <remarks>
-    ///     This overload is obsolete. Override <see cref="OnShutdown(ControlledApplication)" /> instead,
+    ///     This overload is obsolete. Override <c>OnShutdown(ControlledApplication)</c> instead,
     ///     or declare a custom <c>OnShutdown</c> method marked with <see cref="RevitApplicationShutdownAttribute" /> with
     ///     DI-resolved parameters, which the framework will discover and invoke automatically.
     /// </remarks>
@@ -194,7 +194,7 @@ public abstract class RevitAppBase
     ///     A boolean value indicating whether the startup process was successful.
     /// </returns>
     /// <remarks>
-    ///     This overload is obsolete. Override <see cref="OnStartup(ControlledApplication)" /> instead,
+    ///     This overload is obsolete. Override <c>OnStartup(ControlledApplication)</c> instead,
     ///     or declare a custom <c>OnStartup</c> method marked with <see cref="RevitApplicationStartupAttribute" /> with
     ///     DI-resolved parameters, which the framework will discover and invoke automatically.
     /// </remarks>
@@ -293,7 +293,7 @@ public abstract class RevitAppBase
     ///     Dispatches the startup call. Resolution priority:
     ///     <list type="number">
     ///         <item>A method marked with <see cref="RevitApplicationStartupAttribute" /> — all parameters resolved from DI.</item>
-    ///         <item><see cref="OnStartup(ControlledApplication)" /> — if overridden in the derived class.</item>
+    ///         <item><c>OnStartup(ControlledApplication)</c> — if overridden in the derived class.</item>
     ///         <item><see cref="OnStartup()" /> — obsolete parameter-less fallback.</item>
     ///     </list>
     /// </summary>
@@ -306,7 +306,7 @@ public abstract class RevitAppBase
     ///     Dispatches the shutdown call. Resolution priority:
     ///     <list type="number">
     ///         <item>A method marked with <see cref="RevitApplicationShutdownAttribute" /> — all parameters resolved from DI.</item>
-    ///         <item><see cref="OnShutdown(ControlledApplication)" /> — if overridden in the derived class.</item>
+    ///         <item><c>OnShutdown(ControlledApplication)</c> — if overridden in the derived class.</item>
     ///         <item><see cref="OnShutdown()" /> — obsolete parameter-less fallback.</item>
     ///     </list>
     /// </summary>

--- a/Source/Scotec.Revit/RevitCommand.cs
+++ b/Source/Scotec.Revit/RevitCommand.cs
@@ -619,7 +619,7 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     /// <summary>
     ///     Finds the unique method in the type hierarchy that is marked with <typeparamref name="TAttribute" />,
     ///     resolves its parameters from the <paramref name="serviceProvider" />, and invokes it.
-    ///     Does nothing if no such method exists. Throws <see cref="InvalidOperationException" /> if more than one
+    ///     Does nothing if no such method exists. Throws <see cref="System.InvalidOperationException" /> if more than one
     ///     method in the hierarchy carries the attribute.
     /// </summary>
     /// <typeparam name="TAttribute">The lifecycle attribute type to search for.</typeparam>
@@ -649,7 +649,7 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     ///     exists in the type hierarchy, it is invoked with DI-resolved parameters. Otherwise falls back to the
     ///     standard <see cref="OnExecute(ExternalCommandData, ElementSet)" /> override, and finally to the obsolete
     ///     <see cref="OnExecute(ExternalCommandData, IServiceProvider)" /> for backward compatibility.
-    ///     Throws <see cref="InvalidOperationException" /> if more than one method carries the attribute.
+    ///     Throws <see cref="System.InvalidOperationException" /> if more than one method carries the attribute.
     /// </summary>
     /// <param name="commandData">The current <see cref="ExternalCommandData" /> instance.</param>
     /// <param name="elements">The <see cref="ElementSet" /> for the current command execution.</param>

--- a/Source/Scotec.Revit/RevitCommandAvailability.cs
+++ b/Source/Scotec.Revit/RevitCommandAvailability.cs
@@ -112,7 +112,7 @@ public abstract class RevitCommandAvailability : IExternalCommandAvailability
     ///     <c>true</c> if the command is available for execution; otherwise, <c>false</c>.
     /// </returns>
     /// <remarks>
-    ///     This method is obsolete. Override <see cref="IsCommandAvailable(UIApplication, CategorySet)" /> instead,
+    ///     This method is obsolete. Override <see cref="IsCommandAvailable(Autodesk.Revit.UI.UIApplication, Autodesk.Revit.DB.CategorySet)" /> instead,
     ///     or declare a custom <c>IsCommandAvailable</c> overload with DI-resolved parameters, which the framework will
     ///     discover and invoke automatically.
     ///     This method will not be called if a custom <c>IsCommandAvailable</c> overload is provided in the derived class.
@@ -150,9 +150,9 @@ public abstract class RevitCommandAvailability : IExternalCommandAvailability
     ///     Invokes the availability-check entry point. If a method marked with
     ///     <see cref="RevitCommandAvailabilityCheckAttribute" /> exists in the type hierarchy it is invoked with
     ///     DI-resolved parameters. Otherwise falls back to the standard
-    ///     <see cref="IsCommandAvailable(UIApplication, CategorySet)" /> override, and finally to the obsolete
-    ///     <see cref="IsCommandAvailable(UIApplication, CategorySet, IServiceProvider)" /> for backward compatibility.
-    ///     Throws <see cref="InvalidOperationException" /> if more than one method carries the attribute.
+    ///     <see cref="IsCommandAvailable(Autodesk.Revit.UI.UIApplication, Autodesk.Revit.DB.CategorySet)" /> override, and finally to the obsolete
+    ///     <see cref="IsCommandAvailable(Autodesk.Revit.UI.UIApplication, Autodesk.Revit.DB.CategorySet, System.IServiceProvider)" /> for backward compatibility.
+    ///     Throws <see cref="System.InvalidOperationException" /> if more than one method carries the attribute.
     /// </summary>
     private bool InvokeIsCommandAvailable(UIApplication applicationData, CategorySet selectedCategories,
                                           IServiceProvider serviceProvider)

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -20,14 +20,26 @@ internal class RevitContext : IRevitContext, IDisposable
 
     public Application Application
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : field;
-        set => field = Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            // Revit API: Application.IsValidObject must be checked before access after potential application lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit application is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
     public Document Document
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : field;
-        set => field = Disposed ? throw new ObjectDisposedException(nameof(RevitContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            // Revit API: Document.IsValidObject must be checked before access after potential document lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit document is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
     public void Dispose()

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -29,8 +29,7 @@ internal class RevitContext : IRevitContext, IDisposable
     {
         ArgumentNullException.ThrowIfNull(application);
         Application = application;
-        Document = null!;
-        // Document is not set. The Document getter throws InvalidOperationException when accessed.
+        // Document is intentionally left null for no-document contexts.
     }
 
     protected bool Disposed { get; private set; }
@@ -47,14 +46,12 @@ internal class RevitContext : IRevitContext, IDisposable
         private init;
     }
 
-    public Document Document
+    public Document? Document
     {
         get
         {
             ObjectDisposedException.ThrowIf(Disposed, GetType());
-            // ReferenceEquals avoids a false NRT warning: the Revit API is not fully nullable-annotated
-            // so the backing field may be null at runtime even though the property type is non-nullable.
-            if (ReferenceEquals(field, null)) throw new InvalidOperationException("No document is available in the current context.");
+            if (field is null) return null;
             // Revit API: Document.IsValidObject must be checked before access after potential document lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit document is no longer valid.");
             return field;

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -10,10 +10,27 @@ namespace Scotec.Revit;
 
 internal class RevitContext : IRevitContext, IDisposable
 {
+    /// <summary>
+    ///     Initializes a new instance for contexts where a document is available,
+    ///     for example event handlers and transaction commands.
+    /// </summary>
     public RevitContext(Document document)
     {
+        ArgumentNullException.ThrowIfNull(document);
         Document = document;
         Application = document.Application;
+    }
+
+    /// <summary>
+    ///     Initializes a new instance for contexts where no document is required,
+    ///     for example commands that run without an open document.
+    /// </summary>
+    protected RevitContext(Application application)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+        Application = application;
+        Document = null!;
+        // Document is not set. The Document getter throws InvalidOperationException when accessed.
     }
 
     protected bool Disposed { get; private set; }
@@ -22,24 +39,28 @@ internal class RevitContext : IRevitContext, IDisposable
     {
         get
         {
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            ObjectDisposedException.ThrowIf(Disposed, GetType());
             // Revit API: Application.IsValidObject must be checked before access after potential application lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit application is no longer valid.");
             return field;
         }
-        private init => field = value;
+        private init;
     }
 
     public Document Document
     {
         get
         {
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitContext));
+            ObjectDisposedException.ThrowIf(Disposed, GetType());
+            // ReferenceEquals avoids a false NRT warning: the Revit API is not fully nullable-annotated
+            // so the backing field may be null at runtime even though the property type is non-nullable.
+            if (ReferenceEquals(field, null)) throw new InvalidOperationException("No document is available in the current context.");
             // Revit API: Document.IsValidObject must be checked before access after potential document lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit document is no longer valid.");
             return field;
         }
-        private init => field = value;
+        // private protected: accessible from RevitUiContext (same assembly, derived type) during construction.
+        private protected init;
     }
 
     public void Dispose()

--- a/Source/Scotec.Revit/RevitContext.cs
+++ b/Source/Scotec.Revit/RevitContext.cs
@@ -25,7 +25,7 @@ internal class RevitContext : IRevitContext, IDisposable
     ///     Initializes a new instance for contexts where no document is required,
     ///     for example commands that run without an open document.
     /// </summary>
-    protected RevitContext(Application application)
+    protected internal RevitContext(Application application)
     {
         ArgumentNullException.ThrowIfNull(application);
         Application = application;

--- a/Source/Scotec.Revit/RevitDbApp.cs
+++ b/Source/Scotec.Revit/RevitDbApp.cs
@@ -181,6 +181,7 @@ public abstract class RevitDbApp : RevitAppBase, IExternalDBApplication
         {
             services.AddSingleton(Application);
             services.AddSingleton(Application.ActiveAddInId);
+            services.AddGlobalRevitContext(Application);
         });
     }
 }

--- a/Source/Scotec.Revit/RevitGlobalContextExtensions.cs
+++ b/Source/Scotec.Revit/RevitGlobalContextExtensions.cs
@@ -1,0 +1,72 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using Autodesk.Revit.ApplicationServices;
+using Autodesk.Revit.UI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Extension methods for registering the application-lifetime Revit context singletons
+///     (<see cref="IGlobalRevitContext" /> / <see cref="IGlobalRevitUiContext" />) into an
+///     <see cref="IServiceCollection" />.
+/// </summary>
+public static class RevitGlobalContextExtensions
+{
+    /// <summary>
+    ///     Registers <see cref="GlobalRevitContext" /> as <see cref="IGlobalRevitContext" /> in the
+    ///     service collection. Use this overload for DB-level add-ins (<see cref="RevitDbApp" />)
+    ///     that do not have a <see cref="UIApplication" />.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="application">
+    ///     The <see cref="ControlledApplication" /> provided by Revit at add-in startup.
+    /// </param>
+    /// <returns>The same <see cref="IServiceCollection" /> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="services" /> or <paramref name="application" /> is <c>null</c>.
+    /// </exception>
+    public static IServiceCollection AddGlobalRevitContext(
+        this IServiceCollection services,
+        ControlledApplication application)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(application);
+
+        var context = new GlobalRevitContext(application);
+        services.AddSingleton<IGlobalRevitContext>(context);
+
+        return services;
+    }
+
+    /// <summary>
+    ///     Registers <see cref="GlobalRevitUiContext" /> as both <see cref="IGlobalRevitUiContext" />
+    ///     and <see cref="IGlobalRevitContext" /> in the service collection, sharing a single instance.
+    ///     Use this overload for UI add-ins (<see cref="RevitApp" />) that have a
+    ///     <see cref="UIApplication" />.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="application">
+    ///     The <see cref="UIControlledApplication" /> provided by Revit at add-in startup.
+    /// </param>
+    /// <returns>The same <see cref="IServiceCollection" /> for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="services" /> or <paramref name="application" /> is <c>null</c>.
+    /// </exception>
+    public static IServiceCollection AddGlobalRevitContext(
+        this IServiceCollection services,
+        UIControlledApplication application)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(application);
+
+        var context = new GlobalRevitUiContext(application);
+        services.AddSingleton<IGlobalRevitUiContext>(context);
+        services.AddSingleton<IGlobalRevitContext>(context);
+
+        return services;
+    }
+}

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -30,7 +30,6 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         get
         {
             ObjectDisposedException.ThrowIf(Disposed, typeof(RevitUiContext));
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
             // Revit API: UIApplication.IsValidObject must be checked before access after potential application lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
             return field;

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -11,38 +11,45 @@ namespace Scotec.Revit;
 internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 {
     public RevitUiContext(UIApplication uiApplication)
-        // Revit API: ActiveUIDocument may be null when no document is open; guard before dereferencing.
-        : base((uiApplication ?? throw new ArgumentNullException(nameof(uiApplication))).ActiveUIDocument?.Document
-               ?? throw new ArgumentException("No active UI document is open.", nameof(uiApplication)))
+        // Revit API: ActiveUIDocument may be null when no document is open.
+        // Pass Application only; Document is set below when a UI document is available.
+        : base((uiApplication ?? throw new ArgumentNullException(nameof(uiApplication))).Application)
     {
         UiApplication = uiApplication;
-        UiDocument = uiApplication.ActiveUIDocument;
+
+        if (uiApplication.ActiveUIDocument is { } uiDocument)
+        {
+            // Set Document on the base class via private protected init.
+            Document = uiDocument.Document;
+            UiDocument = uiDocument;
+        }
     }
 
     public UIApplication UiApplication
     {
         get
         {
+            ObjectDisposedException.ThrowIf(Disposed, typeof(RevitUiContext));
             if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
             // Revit API: UIApplication.IsValidObject must be checked before access after potential application lifecycle events.
             if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
             return field;
         }
-        private init => field = value;
+        private init;
     }
 
-    public UIDocument UiDocument
+    public UIDocument? UiDocument
     {
         get
         {
-            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
+            ObjectDisposedException.ThrowIf(Disposed, typeof(RevitUiContext));
             // Revit API: UIDocument.IsValidObject must be checked before access after potential document lifecycle events.
-            if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI document is no longer valid.");
+            if (field is not null && !field.IsValidObject) throw new InvalidOperationException("The Revit UI document is no longer valid.");
             return field;
         }
-        private init => field = value;
+        private init;
     }
 
     // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
-    public View ActiveView => UiDocument.ActiveView;
+    public View? ActiveView => UiDocument?.ActiveView;
 }

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -50,5 +50,14 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
     }
 
     // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
-    public View? ActiveView => UiDocument?.ActiveView;
+    // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
+    public View? ActiveView
+    {
+        get
+        {
+            var view = UiDocument?.ActiveView;
+            if (view is not null && !view.IsValidObject) throw new InvalidOperationException("The active Revit view is no longer valid.");
+            return view;
+        }
+    }
 }

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -15,7 +15,7 @@ namespace Scotec.Revit;
 /// <remarks>
 ///     When no document is open at construction time, <see cref="RevitUiContext.UiDocument" />,
 ///     <see cref="RevitContext.Document" />, and <see cref="RevitUiContext.ActiveView" /> are
-///     <c>null</c>; <see cref="RevitUiContext.UiApplication" /> and
+///     <c>null</c>; <see cref="UiApplication" /> and
 ///     <see cref="RevitContext.Application" /> are always set.
 ///     <para>
 ///         All property accessors throw <see cref="ObjectDisposedException" /> after

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -8,8 +8,36 @@ using Autodesk.Revit.UI;
 
 namespace Scotec.Revit;
 
+/// <summary>
+///     Extends <see cref="RevitContext" /> with UI-layer objects: <see cref="UIApplication" />,
+///     <see cref="RevitUiContext.UiDocument" />, and <see cref="RevitUiContext.ActiveView" />.
+/// </summary>
+/// <remarks>
+///     When no document is open at construction time, <see cref="RevitUiContext.UiDocument" />,
+///     <see cref="RevitContext.Document" />, and <see cref="RevitUiContext.ActiveView" /> are
+///     <c>null</c>; <see cref="RevitUiContext.UiApplication" /> and
+///     <see cref="RevitContext.Application" /> are always set.
+///     <para>
+///         All property accessors throw <see cref="ObjectDisposedException" /> after
+///         <see cref="RevitContext.Dispose" /> has been called, and
+///         <see cref="InvalidOperationException" /> when the underlying Revit API object is
+///         no longer valid.
+///     </para>
+/// </remarks>
 internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 {
+    /// <summary>
+    ///     Initializes a new instance from the given <see cref="UIApplication" />.
+    /// </summary>
+    /// <param name="uiApplication">The active Revit UI application.</param>
+    /// <remarks>
+    ///     When <see cref="UIApplication.ActiveUIDocument" /> is non-null at construction time,
+    ///     <see cref="RevitContext.Document" /> and <see cref="RevitUiContext.UiDocument" /> are
+    ///     populated. Otherwise both remain <c>null</c>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="uiApplication" /> is <c>null</c>.
+    /// </exception>
     public RevitUiContext(UIApplication uiApplication)
         // Revit API: ActiveUIDocument may be null when no document is open.
         // Pass Application only; Document is set below when a UI document is available.
@@ -25,6 +53,16 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         }
     }
 
+    /// <summary>
+    ///     Gets the Revit UI application.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when <see cref="UIApplication.IsValidObject" /> returns <c>false</c>,
+    ///     indicating the UI application object is no longer valid.
+    /// </exception>
     public UIApplication UiApplication
     {
         get
@@ -37,6 +75,18 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         private init;
     }
 
+    /// <summary>
+    ///     Gets the active Revit UI document, or <c>null</c> when no document was open at
+    ///     construction time.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    ///     Thrown when the context has been disposed.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the UI document reference is non-null and
+    ///     <see cref="UIDocument.IsValidObject" /> returns <c>false</c>,
+    ///     indicating the document has been closed or invalidated.
+    /// </exception>
     public UIDocument? UiDocument
     {
         get
@@ -49,7 +99,19 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
         private init;
     }
 
-    // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
+    /// <summary>
+    ///     Gets the view currently active in <see cref="RevitUiContext.UiDocument" />, or
+    ///     <c>null</c> when no document is open.
+    /// </summary>
+    /// <remarks>
+    ///     This is a lazy property: it reflects the view active at the moment of access
+    ///     rather than at handler invocation start.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the returned <see cref="View" /> reference is non-null and
+    ///     <see cref="View.IsValidObject" /> returns <c>false</c>,
+    ///     indicating the view has been closed or invalidated.
+    /// </exception>
     // Revit API: View.IsValidObject must be checked before access after potential document lifecycle events.
     public View? ActiveView
     {

--- a/Source/Scotec.Revit/RevitUiContext.cs
+++ b/Source/Scotec.Revit/RevitUiContext.cs
@@ -10,7 +10,10 @@ namespace Scotec.Revit;
 
 internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 {
-    public RevitUiContext(UIApplication uiApplication) : base(uiApplication.ActiveUIDocument.Document)
+    public RevitUiContext(UIApplication uiApplication)
+        // Revit API: ActiveUIDocument may be null when no document is open; guard before dereferencing.
+        : base((uiApplication ?? throw new ArgumentNullException(nameof(uiApplication))).ActiveUIDocument?.Document
+               ?? throw new ArgumentException("No active UI document is open.", nameof(uiApplication)))
     {
         UiApplication = uiApplication;
         UiDocument = uiApplication.ActiveUIDocument;
@@ -18,16 +21,28 @@ internal sealed class RevitUiContext : RevitContext, IRevitUiContext
 
     public UIApplication UiApplication
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : field;
-        private init => field = Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
+            // Revit API: UIApplication.IsValidObject must be checked before access after potential application lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI application is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
     public UIDocument UiDocument
     {
-        get => Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : field;
-        private init => field = Disposed ? throw new ObjectDisposedException(nameof(RevitUiContext)) : value;
+        get
+        {
+            if (Disposed) throw new ObjectDisposedException(nameof(RevitUiContext));
+            // Revit API: UIDocument.IsValidObject must be checked before access after potential document lifecycle events.
+            if (!field.IsValidObject) throw new InvalidOperationException("The Revit UI document is no longer valid.");
+            return field;
+        }
+        private init => field = value;
     }
 
-    // Lazy property, to reflect the view active at the moment of access rather than at handler invocation start.
+    // Lazy property: reflects the view active at the moment of access rather than at handler invocation start.
     public View ActiveView => UiDocument.ActiveView;
 }

--- a/Source/Scotec.Revit/SerialDisposable.cs
+++ b/Source/Scotec.Revit/SerialDisposable.cs
@@ -1,0 +1,53 @@
+﻿// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     A thread-safe container that holds at most one <see cref="System.IDisposable" /> at a time.
+/// </summary>
+/// <remarks>
+///     Assigning a new value to <see cref="Disposable" /> atomically replaces and immediately disposes
+///     the previous value. Disposing the container disposes the current inner value and releases the reference.
+/// </remarks>
+public sealed class SerialDisposable : IDisposable
+{
+    private IDisposable? _disposable;
+
+    /// <summary>
+    ///     Gets or sets the current inner disposable.
+    /// </summary>
+    /// <value>
+    ///     The current <see cref="System.IDisposable" />, or <c>null</c> when none is set or after
+    ///     <see cref="Dispose" /> has been called.
+    /// </value>
+    /// <remarks>
+    ///     The setter atomically replaces the held value and immediately disposes the previous one.
+    ///     Assigning <c>null</c> disposes and clears the current value without assigning a replacement.
+    /// </remarks>
+    public IDisposable? Disposable
+    {
+        get => _disposable;
+        set
+        {
+            var old = Interlocked.Exchange(ref _disposable, value);
+            old?.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///     Disposes the current inner value and releases the reference.
+    /// </summary>
+    /// <remarks>
+    ///     The inner disposable is atomically exchanged with <c>null</c> before disposal,
+    ///     making this method safe to call multiple times.
+    /// </remarks>
+    public void Dispose()
+    {
+        Interlocked.Exchange(ref _disposable, null)?.Dispose();
+    }
+}


### PR DESCRIPTION
## What Changed

### Revit API — New context layer

Introduced a two-tier context abstraction that replaces ad-hoc `Document` / `UIApplication`
access across the codebase.

**Scoped contexts** (per-invocation lifetime):

- `IRevitContext` — `Application` + `Document`; available inside any event handler or external command.
- `IRevitUiContext : IRevitContext` — adds `UiApplication`, `UiDocument`, `ActiveView`; available in UI event handlers and external commands.
- `RevitContext` / `RevitUiContext` — internal implementations; enforce `IsValidObject` and
  `ObjectDisposedException` guards on every property accessor.

**Global (singleton) contexts** (add-in lifetime):

- `IGlobalRevitContext` — singleton access to `Application`; registered for both `RevitApp` and
  `RevitDbApp` add-ins.
- `IGlobalRevitUiContext : IGlobalRevitContext` — adds `UiApplication`, `UiDocument`,
  `ActiveDocument`, `ActiveView`; registered for `RevitApp` add-ins only.
- `GlobalRevitContext` / `GlobalRevitUiContext` — public implementations. `GlobalRevitUiContext`
  caches the `UIApplication` wrapper (1:1 relationship with `Application`).
- `RevitGlobalContextExtensions.AddGlobalRevitContext(...)` — two overloads for
  `ControlledApplication` (DB add-ins) and `UIControlledApplication` (UI add-ins); called
  automatically from `RevitApp.OnConfigure` and `RevitDbApp.OnConfigure`.

**Supporting utility:**

- `SerialDisposable` — thread-safe container holding at most one `IDisposable`; used internally
  by `GlobalRevitContext` to manage the `ApplicationInitialized` subscription lifetime.

### Revit API — Event handler context creation fixes

- `RevitPreEventHandler` and `RevitSingleEventHandler`: `CreateContext` now returns an
  `IRevitContext` wrapping `Application` when the sender is non-null, instead of always returning
  `null`. This makes `IRevitContext` available in the DI scope for pre-event and single-event
  handlers.
- `RevitPreDocumentEventHandler`: aligned `CreateContext` with post-document behaviour — prefers
  `args.Document` when available, falls back to `Application` sender.
- `RevitUiPreEventHandler`, `RevitUiPreDocumentEventHandler`, `RevitUiSingleEventHandler`:
  `CreateContext` now creates `RevitUiContext` from sender unconditionally, removing the
  `ActiveUIDocument != null` guard that prevented context creation when no document was open.

### DI — `RevitDbApp` global context registration

- `RevitDbApp.OnConfigure` now calls `AddGlobalRevitContext(Application)`, registering
  `IGlobalRevitContext` as a singleton. Previously this registration was missing for DB-level
  add-ins.

### XML Documentation

- All public and internal members across `IRevitContext`, `IRevitUiContext`, `RevitContext`,
  `RevitUiContext`, `IGlobalRevitContext`, `IGlobalRevitUiContext`, `GlobalRevitContext`,
  `GlobalRevitUiContext`, `RevitApp`, `RevitAppBase`, `RevitCommand`, `RevitCommandAvailability`,
  and all event handler convenience base classes received complete XML documentation.
- All `<see cref="..."/>` references across the affected files corrected to fully qualified
  Revit API type names, resolving CS1574 and CS0419 build warnings.

### Documentation

- `Documentation/RevitContext.md` — new developer guide covering the context interface hierarchy,
  lifetimes, injection patterns, registration, and common mistakes.
- `Documentation/RevitContextDesign.md` — updated design rationale explaining why singleton
  document providers are structurally inferior to scoped contexts, with accurate Revit API examples
  and comparison table.

## Risks

- `RevitPreEventHandler.CreateContext` and `RevitSingleEventHandler.CreateContext` now return a
  non-null context when they previously returned `null`. Services resolving `IRevitContext` from
  these scopes will now receive a context wrapping `Application` only (`Document` is `null`).
  Callers that assumed `IRevitContext` would not be resolvable in these handlers will need to
  handle a non-null but document-less context.
- `RevitUiPreEventHandler`/`RevitUiSingleEventHandler` now create `RevitUiContext` even when no
  document is open. `UiDocument` and `ActiveView` will return `null` in that case; code that
  previously relied on the null-context path to bail out early must now null-check these
  properties instead.

## Breaking Changes

- `IRevitContext.Document` is now `Document?` (nullable). Callers that previously treated
  `Document` as always non-null must add null checks.
- `IRevitUiContext.ActiveView` is now `View?` (nullable). Same requirement.
- `RevitDbApp` now registers `IGlobalRevitContext` automatically. Add-ins that registered it
  manually in `OnConfigure` will encounter a duplicate registration.