### PR TITLE
Add Revit context tracking and scope factory support

### DIFF
--- a/Source/Scotec.Revit.Test/ShowTestDialogCommand.cs
+++ b/Source/Scotec.Revit.Test/ShowTestDialogCommand.cs
@@ -6,6 +6,7 @@ using System;
 using System.Windows;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Microsoft.Extensions.DependencyInjection;
 using Scotec.Revit.Isolation;
 
 namespace Scotec.Revit.Test;
@@ -28,8 +29,9 @@ public class ShowTestDialogCommand : RevitCommand
     }
 
     [RevitCommandExecute]
-    protected Result Run(IRevitUiContext context, TestRevitDialog dialog) 
+    protected Result Run(IRevitUiContext context, TestRevitDialog dialog, IServiceScopeFactory scopeFactory)
     {
+        using var scope = scopeFactory.CreateScope();
         dialog.Show();
         return Result.Succeeded;
     }

--- a/Source/Scotec.Revit/ContainerBuilderExtensions.cs
+++ b/Source/Scotec.Revit/ContainerBuilderExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Extension methods for <see cref="ContainerBuilder" /> used internally by the Scotec.Revit framework.
+/// </summary>
+internal static class ContainerBuilderExtensions
+{
+    /// <summary>
+    ///     Populates the container builder from <paramref name="services" /> and immediately overrides the
+    ///     <see cref="IServiceScopeFactory" /> registration so that it resolves to
+    ///     <see cref="IRevitScopeFactory" /> rather than Autofac's built-in <c>AutofacServiceScopeFactory</c>.
+    /// </summary>
+    /// <remarks>
+    ///     Autofac's <c>Populate</c> extension unconditionally re-registers <c>AutofacServiceScopeFactory</c>
+    ///     as <see cref="IServiceScopeFactory" /> inside every lifetime scope it is called in. Because Autofac
+    ///     resolves the last registration for a given service type, registering the forwarding rule immediately
+    ///     after <c>Populate</c> ensures that <see cref="IServiceScopeFactory" /> always resolves to
+    ///     <see cref="RevitScopeFactory" /> in that scope — making the Revit-aware factory transparent to
+    ///     callers that inject the standard interface.
+    /// </remarks>
+    /// <param name="builder">The <see cref="ContainerBuilder" /> to populate.</param>
+    /// <param name="services">The <see cref="IServiceCollection" /> whose descriptors are added to the builder.</param>
+    internal static void PopulateRevit(this ContainerBuilder builder, IServiceCollection services)
+    {
+        builder.Populate(services);
+
+        // Override the IServiceScopeFactory that Populate installs with a forwarding rule to
+        // IRevitScopeFactory. Autofac uses last-registration-wins for default service resolution,
+        // so this registration takes precedence over AutofacServiceScopeFactory in this scope.
+        builder.Register(ctx => ctx.Resolve<IRevitScopeFactory>())
+               .As<IServiceScopeFactory>()
+               .InstancePerLifetimeScope();
+    }
+}

--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -300,6 +300,7 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
     /// <param name="args">The event args.</param>
     protected void HandleEvent(object? sender, TEventArgs args)
     {
+        using var _ = RevitContextTracker.Activate();
         EventArgs = args;
         var typedSender = sender as TSender;
 
@@ -325,7 +326,7 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
                     // Same instance. Use ExternallyOwned here to avoid multiple calls to Dispose.
                     builder.RegisterInstance(uiContext).As<IRevitUiContext>().ExternallyOwned();
                 }
-                builder.Populate(services);
+                builder.PopulateRevit(services);
             });
             serviceProvider = scope.Resolve<IServiceProvider>();
         }
@@ -377,7 +378,7 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
                     {
                         var extra = new ServiceCollection();
                         registration.ConfigureServices(extra);
-                        builder.Populate(extra);
+                        builder.PopulateRevit(extra);
                     });
                     resolvedProvider = childScope.Resolve<IServiceProvider>();
                 }

--- a/Source/Scotec.Revit/IRevitScopeFactory.cs
+++ b/Source/Scotec.Revit/IRevitScopeFactory.cs
@@ -1,0 +1,62 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Creates a child <see cref="IServiceScope" /> from the current DI scope, registering
+///     <see cref="IRevitContext" /> and <see cref="IRevitUiContext" /> only when necessary.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <see cref="CreateScope" /> applies the following decision tree on every call:
+///     </para>
+///     <list type="number">
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="false" /></strong>
+///             (env var is <c>0</c> or absent) — no Revit entry point is executing anywhere in
+///             the process. A plain child scope is returned with no context objects.
+///         </item>
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="true" /></strong>
+///             and <see cref="IRevitContext" /> is already resolvable from the current scope —
+///             this add-in's own entry point owns the context. A plain child scope is returned;
+///             <see cref="IRevitContext" /> / <see cref="IRevitUiContext" /> are inherited
+///             through the Autofac scope chain automatically.
+///         </item>
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="true" /></strong>
+///             but <see cref="IRevitContext" /> is <em>not</em> resolvable from the current scope —
+///             the active entry point belongs to a different add-in. A fresh context is constructed
+///             from the application-lifetime <see cref="IGlobalRevitUiContext" /> (UI add-in) or
+///             <see cref="IGlobalRevitContext" /> (DB add-in) and registered in the new child scope.
+///         </item>
+///     </list>
+///     <para>
+///         This factory is registered automatically by <see cref="RevitApp" /> and
+///         <see cref="RevitDbApp" />. No manual call to <c>AddRevitScopeFactory()</c> is required.
+///         The returned <see cref="IServiceScope" /> is owned by the caller and must be disposed
+///         when the operation is complete.
+///     </para>
+/// </remarks>
+[PublicAPI]
+public interface IRevitScopeFactory : IServiceScopeFactory
+{
+    /// <summary>
+    ///     Creates a new child scope, registering Revit context objects as described in the
+    ///     class-level remarks.
+    /// </summary>
+    /// <param name="configure">
+    ///     An optional callback to register additional services into the scope before it is
+    ///     returned. Pass <see langword="null" /> when no extra registrations are needed.
+    /// </param>
+    /// <returns>
+    ///     A new <see cref="IServiceScope" />. The caller is responsible for disposing the scope.
+    /// </returns>
+    new IServiceScope CreateScope(Action<IServiceCollection>? configure = null);
+}

--- a/Source/Scotec.Revit/RevitApp.cs
+++ b/Source/Scotec.Revit/RevitApp.cs
@@ -162,6 +162,7 @@ public abstract class RevitApp : RevitAppBase, IExternalApplication
             services.TryAddSingleton(Application.ActiveAddInId);
             services.TryAddSingleton(Application.ControlledApplication);
             services.AddGlobalRevitContext(Application);
+            services.AddRevitScopeFactory();
         });
     }
 }

--- a/Source/Scotec.Revit/RevitCommand.cs
+++ b/Source/Scotec.Revit/RevitCommand.cs
@@ -292,6 +292,7 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     /// </exception>
     Result IExternalCommand.Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
     {
+        using var _ = RevitContextTracker.Activate();
         var context = new RevitUiContext(commandData.Application);
         var autofacRoot = RevitAppBase.GetServiceProvider().GetAutofacRoot();
 
@@ -530,7 +531,7 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
             // Allow derived classes to add services
             var services = new ServiceCollection();
             ConfigureServices(services);
-            builder.Populate(services);
+            builder.PopulateRevit(services);
         });
     }
 

--- a/Source/Scotec.Revit/RevitCommandAvailability.cs
+++ b/Source/Scotec.Revit/RevitCommandAvailability.cs
@@ -56,6 +56,7 @@ public abstract class RevitCommandAvailability : IExternalCommandAvailability
     /// </remarks>
     bool IExternalCommandAvailability.IsCommandAvailable(UIApplication uiApplication, CategorySet selectedCategories)
     {
+        using var _ = RevitContextTracker.Activate();
         try
         {
             var context = new RevitUiContext(uiApplication);
@@ -70,8 +71,8 @@ public abstract class RevitCommandAvailability : IExternalCommandAvailability
                                               
                                               // Allow derived classes to add services
                                               var services = new ServiceCollection();
-                                              ConfigureServices(services);
-                                              builder.Populate(services);
+                                                              ConfigureServices(services);
+                                                              builder.PopulateRevit(services);
                                           });
 
             var serviceProvider = scope.Resolve<IServiceProvider>();

--- a/Source/Scotec.Revit/RevitContextTracker.cs
+++ b/Source/Scotec.Revit/RevitContextTracker.cs
@@ -1,0 +1,180 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Tracks whether execution is currently inside a Revit-controlled entry point and
+///     exposes that state through a process-wide environment variable.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A Revit context is considered active when the call stack includes at least one of
+///         the following Revit-controlled entry points:
+///         <list type="bullet">
+///             <item>External command execution (<see cref="Autodesk.Revit.UI.IExternalCommand.Execute" />)</item>
+///             <item>Command availability check (<see cref="Autodesk.Revit.UI.IExternalCommandAvailability.IsCommandAvailable" />)</item>
+///             <item>External event execution (<see cref="Autodesk.Revit.UI.IExternalEventHandler.Execute" />)</item>
+///             <item>Revit application or document event handler dispatch</item>
+///             <item>DMU updater execution (<see cref="Autodesk.Revit.DB.IUpdater.Execute" />)</item>
+///         </list>
+///     </para>
+///     <para>
+///         The environment variable <see cref="VariableName" /> is process-wide and is shared
+///         across all add-ins loaded in the same Revit process. Its value is a non-negative
+///         integer stored as a decimal string. <c>0</c> (or absent) means no context is
+///         active; any value greater than <c>0</c> means at least one context is active.
+///     </para>
+///     <para>
+///         Each entry point increments the counter on entry and decrements it on exit.
+///         This correctly handles the one nesting scenario permitted by the Revit API: a DMU
+///         updater (<see cref="Autodesk.Revit.DB.IUpdater.Execute" />) is called
+///         synchronously during a transaction commit, so it can execute while a command or
+///         event handler is already active on the call stack:
+///     </para>
+///     <code>
+///         IExternalCommand.Execute   counter: 0 → 1
+///           transaction.Commit()
+///             IUpdater.Execute       counter: 1 → 2
+///             IUpdater returns       counter: 2 → 1
+///           transaction.Commit() returns
+///         IExternalCommand returns   counter: 1 → 0
+///     </code>
+///     <para>
+///         Because the counter is stored in the environment variable, increments and
+///         decrements by different add-ins in the same process are visible to all of them.
+///         A value of <c>2</c> therefore correctly signals "a command and a nested updater
+///         are both active" without any add-in needing to know about the others.
+///     </para>
+///     <para>
+///         <see cref="Activate" /> is reserved for the Scotec.Revit framework's own
+///         entry-point implementations. Consumer code should use <see cref="IsActive" />
+///         or read <see cref="VariableName" /> directly.
+///     </para>
+/// </remarks>
+[PublicAPI]
+public static class RevitContextTracker
+{
+    /// <summary>
+    ///     The name of the environment variable that stores the active-context depth counter.
+    /// </summary>
+    /// <remarks>
+    ///     The value is a non-negative integer stored as a decimal string.
+    ///     <c>0</c>, absent, or any non-parseable value means no context is active.
+    ///     The variable is process-wide and is shared by all Scotec.Revit add-ins loaded
+    ///     in the same Revit process.
+    /// </remarks>
+    public const string VariableName = "Scotec.Revit.Context.Active";
+
+    /// <summary>
+    ///     Gets a value indicating whether execution is currently inside at least one
+    ///     Revit-controlled entry point.
+    /// </summary>
+    /// <remarks>
+    ///     Returns <see langword="true" /> when the depth counter stored in
+    ///     <see cref="VariableName" /> is greater than zero.
+    ///     A missing, <see langword="null" />, or non-parseable value is treated as <c>0</c>.
+    /// </remarks>
+    public static bool IsActive => ReadDepth() > 0;
+
+    /// <summary>
+    ///     Gets a value indicating whether <em>this</em> add-in's own entry-point
+    ///     infrastructure has an active Revit context on the current thread.
+    /// </summary>
+    /// <remarks>
+    ///     Unlike <see cref="IsActive" />, which reads the process-wide environment variable
+    ///     and therefore reflects activity in <em>any</em> Scotec.Revit add-in, this property
+    ///     is backed by an in-process static counter that is only modified by <see cref="Activate" />
+    ///     calls from this assembly. It is used by <see cref="RevitScopeFactory" /> to
+    ///     distinguish "this add-in has an active entry point" from "a different add-in has
+    ///     an active entry point".
+    /// </remarks>
+    internal static bool ThisAddInIsActive => _ownDepth > 0;
+
+    // Per-add-in in-process counter. Each assembly has its own static copy.
+    // Revit prevents re-entrance within a single add-in, so the value is
+    // always 0 or 1 — except for the command → DMU updater nesting case where
+    // it may briefly reach 2 within the same add-in.
+    private static int _ownDepth;
+
+    /// <summary>
+    ///     Increments the active-context depth counter and returns a handle that
+    ///     decrements the counter when disposed.
+    /// </summary>
+    /// <returns>
+    ///     An <see cref="IDisposable" /> handle. Disposing it decrements
+    ///     <see cref="VariableName" />. Disposing more than once is safe.
+    /// </returns>
+    /// <remarks>
+    ///     This method is for exclusive use by the Scotec.Revit framework entry-point
+    ///     implementations. Consumer code must not call it.
+    /// </remarks>
+    internal static IDisposable Activate()
+    {
+        Interlocked.Increment(ref _ownDepth);
+        WriteDepth(ReadDepth() + 1);
+        return new Deactivator();
+    }
+
+    // ── Env-var encoding helpers ─────────────────────────────────────────────
+
+    /// <summary>
+    ///     Reads the current depth counter from <see cref="VariableName" />.
+    ///     Returns <c>0</c> when the variable is absent, empty, or non-parseable.
+    ///     Negative values are clamped to <c>0</c>.
+    /// </summary>
+    private static int ReadDepth()
+    {
+        var raw = Environment.GetEnvironmentVariable(VariableName, EnvironmentVariableTarget.Process);
+        return int.TryParse(raw, out var depth) ? Math.Max(0, depth) : 0;
+    }
+
+    /// <summary>
+    ///     Writes <paramref name="depth" /> to <see cref="VariableName" /> as a decimal string.
+    /// </summary>
+    private static void WriteDepth(int depth)
+    {
+        Environment.SetEnvironmentVariable(VariableName, depth.ToString(), EnvironmentVariableTarget.Process);
+    }
+
+    // ── Deactivator ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    ///     Decrements the depth counter in <see cref="VariableName" /> when disposed.
+    /// </summary>
+    private sealed class Deactivator : IDisposable
+    {
+        // int field lets Interlocked.Exchange guard against double-dispose without a lock.
+        private int _disposed;
+
+        public void Dispose()
+        {
+            // Idempotent: only the first call takes effect.
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            // Decrement the per-add-in counter unconditionally — this cannot throw.
+            Interlocked.Decrement(ref _ownDepth);
+
+            try
+            {
+                WriteDepth(Math.Max(0, ReadDepth() - 1));
+            }
+            catch
+            {
+                // Environment.SetEnvironmentVariable can fail in restricted execution
+                // environments (e.g. process isolation or sandboxing). Swallowing here
+                // ensures the entry point's own control flow is not disrupted. Leaving
+                // the counter elevated is the safer failure mode — callers that rely on
+                // IsActive see a false-positive rather than a false-negative.
+            }
+        }
+    }
+}

--- a/Source/Scotec.Revit/RevitDbApp.cs
+++ b/Source/Scotec.Revit/RevitDbApp.cs
@@ -183,6 +183,7 @@ public abstract class RevitDbApp : RevitAppBase, IExternalDBApplication
             services.TryAddSingleton(Application);
             services.TryAddSingleton(Application.ActiveAddInId);
             services.AddGlobalRevitContext(Application);
+            services.AddRevitScopeFactory();
         });
     }
 }

--- a/Source/Scotec.Revit/RevitScopeFactory.cs
+++ b/Source/Scotec.Revit/RevitScopeFactory.cs
@@ -1,0 +1,196 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Scotec.Revit.EventHandler;
+
+namespace Scotec.Revit;
+
+/// <summary>
+///     Default implementation of <see cref="IRevitScopeFactory" />.
+/// </summary>
+/// <remarks>
+///     Registered as a scoped service so that Autofac injects the <see cref="ILifetimeScope" />
+///     and <see cref="IServiceProvider" /> of the <em>current</em> scope at resolution time.
+///     <see cref="CreateScope" /> applies the following decision tree on every call:
+///     <list type="number">
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="false" /></strong>
+///             (env var is <c>0</c> or absent) — no Revit entry point is executing anywhere in the
+///             process. A plain child scope is created with no context objects registered.
+///         </item>
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="true" /></strong>
+///             and <see cref="IRevitContext" /> is resolvable from the current scope — this add-in's
+///             own entry point owns the context and has already registered it. A plain child scope
+///             inherits those registrations through the Autofac scope chain.
+///         </item>
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="true" /></strong>,
+///             <see cref="IRevitContext" /> is <em>not</em> yet resolvable, but
+///             <see cref="RevitContextTracker.ThisAddInIsActive" /> is <see langword="true" /> —
+///             this add-in's own entry point has activated the context tracker but has not yet
+///             registered <see cref="IRevitContext" /> in a DI scope (this is the brief window
+///             between <c>RevitContextTracker.Activate()</c> and scope construction in
+///             <see cref="RevitCommand" />, <see cref="RevitEventHandler{TSender,TEventArgs,TContext}" />,
+///             etc.). A plain child scope is created; the entry point will register the context
+///             in its own scope immediately after.
+///         </item>
+///         <item>
+///             <strong><see cref="RevitContextTracker.IsActive" /> is <see langword="true" /></strong>,
+///             <see cref="IRevitContext" /> is <em>not</em> resolvable, and
+///             <see cref="RevitContextTracker.ThisAddInIsActive" /> is <see langword="false" /></strong>
+///             — the active entry point belongs to a different add-in. A fresh
+///             <see cref="IRevitContext" /> / <see cref="IRevitUiContext" /> is constructed from the
+///             application-lifetime <see cref="IGlobalRevitUiContext" /> or
+///             <see cref="IGlobalRevitContext" /> and registered in the new child scope.
+///         </item>
+///     </list>
+/// </remarks>
+internal sealed class RevitScopeFactory : IRevitScopeFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILifetimeScope _root;
+
+    /// <summary>
+    ///     Initializes a new instance of <see cref="RevitScopeFactory" />.
+    /// </summary>
+    /// <param name="serviceProvider">
+    ///     The service provider of the current scope, used to probe for
+    ///     <see cref="IRevitContext" /> and to resolve the global context singletons when a
+    ///     fresh context is required.
+    /// </param>
+    /// <param name="root">
+    ///     The Autofac lifetime scope of the current resolution context, from which child
+    ///     scopes are created. Autofac injects this contextually for every scope.
+    /// </param>
+    public RevitScopeFactory(IServiceProvider serviceProvider, ILifetimeScope root)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(root);
+        _serviceProvider = serviceProvider;
+        _root = root;
+    }
+
+    /// <inheritdoc />
+    public IServiceScope CreateScope(Action<IServiceCollection>? configure = null)
+    {
+        // ── Branch 1: no active Revit context anywhere in the process ─────────
+        // env var == 0 (or absent). No Revit entry point is executing. Open a
+        // plain child scope — do not register any IRevitContext / IRevitUiContext.
+        if (!RevitContextTracker.IsActive)
+        {
+            return new RevitServiceScope(OpenScope(configure));
+        }
+
+        // ── Branch 2: active context already in this add-in's scope chain ─────
+        // env var >= 1 and IRevitContext is resolvable from the current scope.
+        // The enclosing entry point (RevitCommand, RevitEventHandler, etc.) owns the
+        // context. Open a plain child scope — IRevitContext / IRevitUiContext are
+        // inherited automatically through the Autofac scope chain.
+        if (_serviceProvider.GetService<IRevitContext>() is not null)
+        {
+            return new RevitServiceScope(OpenScope(configure));
+        }
+
+        // ── Branch 3: this add-in's entry point is active but scope not yet built
+        // ThisAddInIsActive is true, meaning Activate() was called by this add-in's
+        // own entry point infrastructure (RevitCommand, RevitEventHandler, etc.) but
+        // its DI scope — and therefore IRevitContext — does not exist yet. This is
+        // the brief window between RevitContextTracker.Activate() and
+        // CreateLifetimeScope() inside the entry point method. A plain child scope is
+        // returned; the entry point will register IRevitContext in its own scope
+        // immediately afterwards. Attempting to create a fresh context here would
+        // duplicate and conflict with that registration.
+        if (RevitContextTracker.ThisAddInIsActive)
+        {
+            return new RevitServiceScope(OpenScope(configure));
+        }
+
+        // ── Branch 4: active context belongs to another add-in ────────────────
+        // env var >= 1, IRevitContext is absent, and this add-in has no active entry
+        // point of its own. The active entry point belongs to a different add-in.
+        // Construct a fresh context from the application-lifetime global and
+        // register it in the new child scope.
+
+        // Branch 4 — UI add-in path.
+        var uiGlobalContext = _serviceProvider.GetService<IGlobalRevitUiContext>();
+        if (uiGlobalContext is not null)
+        {
+            var context = new RevitUiContext(uiGlobalContext.UiApplication);
+            var lifetimeScope = _root.BeginLifetimeScope(builder =>
+            {
+                builder.RegisterInstance(context).As<IRevitContext>().OwnedByLifetimeScope();
+                // Same instance — ExternallyOwned prevents a second Dispose call.
+                builder.RegisterInstance(context).As<IRevitUiContext>().ExternallyOwned();
+                PopulateServices(builder, configure);
+            });
+            return new RevitServiceScope(lifetimeScope);
+        }
+
+        // Branch 4 — DB add-in path.
+        var globalContext = _serviceProvider.GetRequiredService<IGlobalRevitContext>();
+        var dbContext = new RevitContext(globalContext.Application);
+        var dbLifetimeScope = _root.BeginLifetimeScope(builder =>
+        {
+            builder.RegisterInstance(dbContext).As<IRevitContext>().OwnedByLifetimeScope();
+            PopulateServices(builder, configure);
+        });
+        return new RevitServiceScope(dbLifetimeScope);
+    }
+
+    /// <summary>
+    ///     Explicit implementation of <see cref="IServiceScopeFactory.CreateScope" /> so that
+    ///     <see cref="IRevitScopeFactory" /> is a drop-in replacement for
+    ///     <see cref="IServiceScopeFactory" /> — delegates to
+    ///     <see cref="CreateScope(Action{IServiceCollection}?)" /> with no additional service
+    ///     registrations.
+    /// </summary>
+    IServiceScope IServiceScopeFactory.CreateScope() => CreateScope(null);
+
+    /// <summary>
+    ///     Opens a plain child scope, optionally populated with extra services.
+    ///     Used for Branch 1 and Branch 2 where no context objects need to be registered.
+    /// </summary>
+    private ILifetimeScope OpenScope(Action<IServiceCollection>? configure)
+        => configure is null
+            ? _root.BeginLifetimeScope()
+            : _root.BeginLifetimeScope(builder => PopulateServices(builder, configure));
+
+    private static void PopulateServices(ContainerBuilder builder, Action<IServiceCollection>? configure)
+    {
+        if (configure is null)
+        {
+            return;
+        }
+
+        var services = new ServiceCollection();
+        configure(services);
+        builder.PopulateRevit(services);
+    }
+
+    /// <summary>
+    ///     Thin <see cref="IServiceScope" /> wrapper around an Autofac <see cref="ILifetimeScope" />.
+    ///     <see cref="ServiceProvider" /> is obtained via <see cref="ILifetimeScope.Resolve{T}" />,
+    ///     which returns the Autofac-backed <see cref="IServiceProvider" /> already registered
+    ///     for every child scope. Disposing this wrapper disposes the underlying lifetime scope.
+    /// </summary>
+    private sealed class RevitServiceScope : IServiceScope
+    {
+        private readonly ILifetimeScope _lifetimeScope;
+
+        internal RevitServiceScope(ILifetimeScope lifetimeScope)
+        {
+            _lifetimeScope = lifetimeScope;
+            ServiceProvider = lifetimeScope.Resolve<IServiceProvider>();
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public void Dispose() => _lifetimeScope.Dispose();
+    }
+}

--- a/Source/Scotec.Revit/RevitTask.cs
+++ b/Source/Scotec.Revit/RevitTask.cs
@@ -71,6 +71,7 @@ public sealed class RevitTask : IExternalEventHandler, IDisposable
     /// </remarks>
     void IExternalEventHandler.Execute(UIApplication uiApplication)
     {
+        using var _ = RevitContextTracker.Activate();
         try
         {
             if (_function is not null)
@@ -283,7 +284,7 @@ public sealed class RevitTask : IExternalEventHandler, IDisposable
                                // Allow to add services
                                var services = new ServiceCollection();
                                configureServices?.Invoke(services);
-                               builder.Populate(services);
+                               builder.PopulateRevit(services);
                            });
     }
 

--- a/Source/Scotec.Revit/RevitUpdater.cs
+++ b/Source/Scotec.Revit/RevitUpdater.cs
@@ -97,6 +97,7 @@ public abstract class RevitUpdater : IUpdater, IDisposable
     /// <inheritdoc />
     void IUpdater.Execute(UpdaterData data)
     {
+        using var _ = RevitContextTracker.Activate();
         var context = new RevitContext(data.GetDocument());
 
         using var scope = RevitAppBase.GetServiceProvider()
@@ -108,7 +109,7 @@ public abstract class RevitUpdater : IUpdater, IDisposable
 
                                           var services = new ServiceCollection();
                                           ConfigureServices(services);
-                                          builder.Populate(services);
+                                          builder.PopulateRevit(services);
                                       });
 
         var serviceProvider = scope.Resolve<IServiceProvider>();

--- a/Source/Scotec.Revit/ServiceExtensions.cs
+++ b/Source/Scotec.Revit/ServiceExtensions.cs
@@ -103,3 +103,32 @@ public static class RevitTaskServiceExtensions
         return services;
     }
 }
+
+/// <summary>
+///     Extension methods for registering <see cref="Scotec.Revit.IRevitScopeFactory" /> into an
+///     <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection" />.
+/// </summary>
+public static class RevitScopeFactoryServiceExtensions
+{
+    /// <summary>
+    ///     Registers <see cref="Scotec.Revit.RevitScopeFactory" /> as <see cref="Scotec.Revit.IRevitScopeFactory" />
+    ///     in the service collection.
+    /// </summary>
+    /// <remarks>
+    ///     This registration is performed automatically by <see cref="Scotec.Revit.RevitApp" /> and
+    ///     <see cref="Scotec.Revit.RevitDbApp" />. It only needs to be called manually in test
+    ///     harnesses or host configurations that do not derive from those base classes.
+    /// </remarks>
+    /// <param name="services">The service collection to register into.</param>
+    /// <returns>The same <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection" /> for chaining.</returns>
+    /// <exception cref="System.ArgumentNullException">
+    ///     Thrown when <paramref name="services" /> is <c>null</c>.
+    /// </exception>
+    public static IServiceCollection AddRevitScopeFactory(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.TryAddScoped<IRevitScopeFactory, RevitScopeFactory>();
+
+        return services;
+    }
+}


### PR DESCRIPTION
Introduce RevitContextTracker for entry point detection using a process-wide environment variable and per-add-in counter. Add IRevitScopeFactory and RevitScopeFactory for context-aware DI scope creation, registering context objects only when needed. Add ContainerBuilderExtensions.PopulateRevit to ensure IServiceScopeFactory resolves to IRevitScopeFactory. Update service registration to use PopulateRevit and register AddRevitScopeFactory in RevitApp and RevitDbApp. Entry points now activate the context tracker, improving context isolation and DI scoping across add-ins.