### PR TITLE
Feat: Add structured logging to RevitAppBase, RevitCommand, RevitEventHandler, and RevitUpdater

### DIFF
--- a/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
+++ b/Source/Scotec.Revit/EventHandler/RevitEventHandler.cs
@@ -7,6 +7,7 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -308,36 +309,65 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
         IServiceProvider serviceProvider;
 
         var autofacRoot = RevitAppBase.GetServiceProvider().GetAutofacRoot();
+        var rootLogger = RevitAppBase.GetServiceProvider().GetService<ILogger<RevitEventHandler<TSender, TEventArgs, TContext>>>();
+        var handlerType = GetType().FullName;
 
         if (UseNewScope)
         {
-            var context = CreateContext(typedSender, args);
-            scope = autofacRoot.BeginLifetimeScope(builder =>
+            try
             {
-                IServiceCollection services = new ServiceCollection();
-                services.AddScoped<TEventArgs>(_ => args);
-                RegisterEventContext(services, typedSender, args);
-                ConfigureServices(services);
-                // IRevitContext is always registered.
-                // IRevitUiContext is additionally registered when the context is a UI context.
-                builder.RegisterInstance(context!).As<IRevitContext>().OwnedByLifetimeScope();
-                if (context is IRevitUiContext uiContext)
+                var context = CreateContext(typedSender, args);
+                scope = autofacRoot.BeginLifetimeScope(builder =>
                 {
-                    // Same instance. Use ExternallyOwned here to avoid multiple calls to Dispose.
-                    builder.RegisterInstance(uiContext).As<IRevitUiContext>().ExternallyOwned();
-                }
-                builder.PopulateRevit(services);
-            });
-            serviceProvider = scope.Resolve<IServiceProvider>();
+                    IServiceCollection services = new ServiceCollection();
+                    services.AddScoped<TEventArgs>(_ => args);
+                    RegisterEventContext(services, typedSender, args);
+                    ConfigureServices(services);
+                    // IRevitContext is always registered.
+                    // IRevitUiContext is additionally registered when the context is a UI context.
+                    builder.RegisterInstance(context!).As<IRevitContext>().OwnedByLifetimeScope();
+                    if (context is IRevitUiContext uiContext)
+                    {
+                        // Same instance. Use ExternallyOwned here to avoid multiple calls to Dispose.
+                        builder.RegisterInstance(uiContext).As<IRevitUiContext>().ExternallyOwned();
+                    }
+                    builder.PopulateRevit(services);
+                });
+                serviceProvider = scope.Resolve<IServiceProvider>();
+            }
+            catch (Exception ex)
+            {
+                rootLogger?.LogError(ex,
+                    "EventHandler {HandlerType}: failed to create lifetime scope for {EventArgsType}.",
+                    handlerType, typeof(TEventArgs).Name);
+                throw;
+            }
         }
         else
         {
             serviceProvider = autofacRoot.Resolve<IServiceProvider>();
         }
 
+        var logger = serviceProvider.GetService<ILogger<RevitEventHandler<TSender, TEventArgs, TContext>>>();
+
+        logger?.LogDebug(
+            "EventHandler {HandlerType}: handling {EventArgsType}.",
+            handlerType, typeof(TEventArgs).Name);
+
         try
         {
-            InvokeOnExecute(typedSender, args, serviceProvider);
+            InvokeOnExecute(typedSender, args, serviceProvider, logger, handlerType);
+
+            logger?.LogInformation(
+                "EventHandler {HandlerType}: {EventArgsType} handled successfully.",
+                handlerType, typeof(TEventArgs).Name);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex,
+                "EventHandler {HandlerType}: unhandled exception while handling {EventArgsType}.",
+                handlerType, typeof(TEventArgs).Name);
+            throw;
         }
         finally
         {
@@ -359,7 +389,8 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
         }
     }
 
-    private void InvokeOnExecute(TSender? sender, TEventArgs args, IServiceProvider serviceProvider)
+    private void InvokeOnExecute(TSender? sender, TEventArgs args, IServiceProvider serviceProvider,
+                                  ILogger? logger, string? handlerType)
     {
         // Delegate-subscription path: runs instead of the attribute/OnExecute path when registrations exist.
         if (_delegateRegistrations.Count > 0)
@@ -389,6 +420,10 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
 
                 try
                 {
+                    logger?.LogDebug(
+                        "EventHandler {HandlerType}: dispatching {EventArgsType} to registered delegate '{DelegateName}'.",
+                        handlerType, typeof(TEventArgs).Name, registration.Action.Method.Name);
+
                     var delegateArgs = RevitReflectionHelper.ResolveParameters(
                         registration.Action.Method, resolvedProvider);
                     registration.Action.DynamicInvoke(delegateArgs);
@@ -402,12 +437,17 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
             return;
         }
 
-        // Legacy attribute/OnExecute path.
+        // Attribute/OnExecute path.
         var method = RevitReflectionHelper.FindSingleAttributedMethod<RevitEventHandlerExecuteAttribute>(
             GetType(), typeof(RevitEventHandler<TSender, TEventArgs, TContext>), typeof(void));
 
         if (method is not null)
         {
+            logger?.LogDebug(
+                "EventHandler {HandlerType}: dispatching {EventArgsType} via [{AttributeName}]-attributed method '{DeclaringType}.{Method}'.",
+                handlerType, typeof(TEventArgs).Name, nameof(RevitEventHandlerExecuteAttribute),
+                method.DeclaringType?.Name, method.Name);
+
             RevitReflectionHelper.Invoke(this, method, serviceProvider,
                 new Dictionary<Type, object>
                 {
@@ -417,6 +457,11 @@ public abstract class RevitEventHandler<TSender, TEventArgs, TContext> : IDispos
 
             return;
         }
+
+        // Virtual OnExecute fallback.
+        logger?.LogDebug(
+            "EventHandler {HandlerType}: no delegates or [{AttributeName}]-attributed method found for {EventArgsType}. Dispatching via virtual OnExecute.",
+            handlerType, nameof(RevitEventHandlerExecuteAttribute), typeof(TEventArgs).Name);
 
         OnExecute(sender, args);
     }

--- a/Source/Scotec.Revit/RevitAppBase.cs
+++ b/Source/Scotec.Revit/RevitAppBase.cs
@@ -12,6 +12,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Scotec.Revit;
 
@@ -224,21 +226,15 @@ public abstract class RevitAppBase
     {
         AddInId = addInId.GetGUID();
 
-        try
-        {
-            var builder = CreateRevitHostBuilder();
-            OnConfigure(builder);
+        var builder = CreateRevitHostBuilder();
+        OnConfigure(builder);
 
-            Host = builder.Build();
-            Host.Start();
+        Host = builder.Build();
 
-            ServiceProvider = Host.Services;
-            return InvokeOnStartup(Host.Services);
-        }
-        catch (Exception)
-        {
-            return false;
-        }
+        Host.Start();
+
+        ServiceProvider = Host.Services;
+        return InvokeOnStartup(Host.Services);
     }
 
     /// <summary>
@@ -338,39 +334,90 @@ public abstract class RevitAppBase
     /// </summary>
     private bool InvokeLifecycleMethod(string methodName, IServiceProvider services)
     {
-        var entryPointAttribute = methodName == "OnStartup"
-            ? typeof(RevitApplicationStartupAttribute)
-            : typeof(RevitApplicationShutdownAttribute);
+        var logger = services.GetService<ILogger<RevitAppBase>>();
+        var addInType = GetType().FullName;
 
-        // Priority 1: method explicitly marked with [RevitStartup] / [RevitShutdown].
-        var attributedMethod = RevitReflectionHelper.FindMethod(
-            GetType(), typeof(RevitAppBase), methodName, typeof(bool),
-            m => m.IsDefined(entryPointAttribute, false));
+        logger?.LogDebug("Add-in {AddInType}: invoking lifecycle method '{MethodName}'.", addInType, methodName);
 
-        if (attributedMethod is not null)
+        try
         {
-            return (bool)RevitReflectionHelper.Invoke(this, attributedMethod, services)!;
-        }
+            var entryPointAttribute = methodName == "OnStartup"
+                ? typeof(RevitApplicationStartupAttribute)
+                : typeof(RevitApplicationShutdownAttribute);
 
-        // Priority 2a: class-specific standard overload (e.g. OnStartup(UIControlledApplication in RevitApp or
-        // OnStartup(ControlledApplication) in RevitDbApp).
-        // Only invoked when the method is overridden below RevitApp / RevitDbApp, not when it is still
-        // the default implementation provided by those framework base classes.
-        var appSpecificMethod = RevitReflectionHelper.FindMethod(
-            GetType(), LifecycleStopType, methodName, typeof(bool),
-            m => m.GetParameters()
-                  .Select(p => p.ParameterType)
-                  .SequenceEqual(StandardLifecycleApplicationSignature));
+            // Priority 1: method explicitly marked with [RevitStartup] / [RevitShutdown].
+            var attributedMethod = RevitReflectionHelper.FindMethod(
+                GetType(), typeof(RevitAppBase), methodName, typeof(bool),
+                m => m.IsDefined(entryPointAttribute, false));
 
-        if (appSpecificMethod is not null)
-        {
-            return (bool)RevitReflectionHelper.Invoke(this, appSpecificMethod, services)!;
-        }
+            if (attributedMethod is not null)
+            {
+                logger?.LogDebug(
+                    "Add-in {AddInType}: dispatching '{MethodName}' via [{AttributeName}]-attributed method '{DeclaringType}.{Method}'.",
+                    addInType, methodName, entryPointAttribute.Name,
+                    attributedMethod.DeclaringType?.Name, attributedMethod.Name);
 
-        // Priority 3: obsolete parameter-less fallback.
+                var result = (bool)RevitReflectionHelper.Invoke(this, attributedMethod, services)!;
+
+                logger?.LogInformation(
+                    "Add-in {AddInType}: lifecycle method '{MethodName}' completed via [{AttributeName}]-attributed method '{DeclaringType}.{Method}' with result {Result}.",
+                    addInType, methodName, entryPointAttribute.Name,
+                    attributedMethod.DeclaringType?.Name, attributedMethod.Name, result);
+
+                return result;
+            }
+
+            // Priority 2: class-specific standard overload (e.g. OnStartup(UIControlledApplication) in RevitApp or
+            // OnStartup(ControlledApplication) in RevitDbApp).
+            // Only invoked when the method is overridden below RevitApp / RevitDbApp, not when it is still
+            // the default implementation provided by those framework base classes.
+            var appSpecificMethod = RevitReflectionHelper.FindMethod(
+                GetType(), LifecycleStopType, methodName, typeof(bool),
+                m => m.GetParameters()
+                      .Select(p => p.ParameterType)
+                      .SequenceEqual(StandardLifecycleApplicationSignature));
+
+            if (appSpecificMethod is not null)
+            {
+                logger?.LogDebug(
+                    "Add-in {AddInType}: dispatching '{MethodName}' via standard override '{DeclaringType}.{Method}'.",
+                    addInType, methodName,
+                    appSpecificMethod.DeclaringType?.Name, appSpecificMethod.Name);
+
+                var result = (bool)RevitReflectionHelper.Invoke(this, appSpecificMethod, services)!;
+
+                logger?.LogInformation(
+                    "Add-in {AddInType}: lifecycle method '{MethodName}' completed via standard override '{DeclaringType}.{Method}' with result {Result}.",
+                    addInType, methodName,
+                    appSpecificMethod.DeclaringType?.Name, appSpecificMethod.Name, result);
+
+                return result;
+            }
+
+            // Priority 3: obsolete parameter-less fallback.
+            logger?.LogWarning(
+                "Add-in {AddInType}: no attributed or standard override found for '{MethodName}'. " +
+                "Falling back to the obsolete parameter-less {MethodName}() overload. " +
+                "Override {MethodName}(ControlledApplication) or declare a method with [Revit{Operation}] instead.",
+                addInType, methodName, methodName, methodName == "OnStartup" ? "Startup" : "Shutdown");
+
 #pragma warning disable CS0618
-        return methodName == "OnStartup" ? OnStartup() : OnShutdown();
+            var fallbackResult = methodName == "OnStartup" ? OnStartup() : OnShutdown();
 #pragma warning restore CS0618
+
+            logger?.LogInformation(
+                "Add-in {AddInType}: lifecycle method '{MethodName}' completed via obsolete fallback with result {Result}.",
+                addInType, methodName, fallbackResult);
+
+            return fallbackResult;
+        }
+        catch (Exception e)
+        {
+            logger?.LogError(e,
+                "Add-in {AddInType}: lifecycle method '{MethodName}' failed with an unhandled exception.",
+                addInType, methodName);
+            throw;
+        }
     }
 
     /// <summary>

--- a/Source/Scotec.Revit/RevitCommand.cs
+++ b/Source/Scotec.Revit/RevitCommand.cs
@@ -11,6 +11,7 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Scotec.Revit;
 
@@ -309,36 +310,55 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
             serviceProvider = autofacRoot.Resolve<IServiceProvider>();
         }
 
+        var logger = serviceProvider.GetService<ILogger<RevitCommand>>();
+        var commandType = GetType().FullName;
+        var documentPath = context.Document?.PathName;
+
+        logger?.LogDebug(
+            "Command {CommandType}: starting execution. Document: '{DocumentPath}'. Transaction mode: {TransactionMode}.",
+            commandType, documentPath ?? "<none>", GetTransactionMode());
+
         try
         {
             var transactionMode = GetTransactionMode();
 
             // Call BeforeExecute before any transaction is opened.
-            InvokeOptionalMethod<RevitCommandBeforeExecuteAttribute>(commandData, elements, serviceProvider);
+            InvokeOptionalMethod<RevitCommandBeforeExecuteAttribute>(commandData, elements, serviceProvider, logger, commandType);
 
             Result result;
 
             // Skip transaction management if no document is open or transaction is not required.
             if (transactionMode == RevitTransactionMode.None || transactionMode == RevitTransactionMode.ReadOnly)
             {
-                result = InvokeOnExecute(commandData, elements, serviceProvider);
+                result = InvokeOnExecute(commandData, elements, serviceProvider, logger, commandType);
             }
             else
             {
                 result = transactionMode switch
                 {
                     RevitTransactionMode.Transaction or RevitTransactionMode.TransactionWithRollback
-                        => ExecuteTransaction(commandData, elements, context.Document, serviceProvider, transactionMode),
+                        => ExecuteTransaction(commandData, elements, context.Document, serviceProvider, transactionMode, logger, commandType),
                     RevitTransactionMode.TransactionGroup or RevitTransactionMode.TransactionGroupWithRollback
-                        => ExecuteTransactionGroup(commandData, elements, context.Document, serviceProvider, transactionMode),
+                        => ExecuteTransactionGroup(commandData, elements, context.Document, serviceProvider, transactionMode, logger, commandType),
                     _ => Result.Failed
                 };
             }
 
             // Call AfterExecute after the transaction has been closed.
-            InvokeOptionalMethod<RevitCommandAfterExecuteAttribute>(commandData, elements, serviceProvider);
+            InvokeOptionalMethod<RevitCommandAfterExecuteAttribute>(commandData, elements, serviceProvider, logger, commandType);
+
+            logger?.LogInformation(
+                "Command {CommandType}: execution completed with result {Result}. Document: '{DocumentPath}'.",
+                commandType, result, documentPath ?? "<none>");
 
             return result;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex,
+                "Command {CommandType}: unhandled exception during execution. Document: '{DocumentPath}'.",
+                commandType, documentPath ?? "<none>");
+            throw;
         }
         finally
         {
@@ -536,14 +556,15 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     }
 
     private Result ExecuteTransactionGroup(ExternalCommandData commandData, ElementSet elements, Document document, IServiceProvider serviceProvider,
-                                           RevitTransactionMode transactionMode)
+                                           RevitTransactionMode transactionMode,
+                                           ILogger? logger = null, string? commandType = null)
     {
         using var transactionGroup = new TransactionGroup(document);
 
         try
         {
             transactionGroup.Start(TransactionName);
-            var result = InvokeOnExecute(commandData, elements, serviceProvider);
+            var result = InvokeOnExecute(commandData, elements, serviceProvider, logger, commandType);
 
             // Do not commit on error or in rollback mode.
             if (result == Result.Succeeded && transactionMode == RevitTransactionMode.TransactionGroup)
@@ -563,7 +584,8 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     }
 
     private Result ExecuteTransaction(ExternalCommandData commandData, ElementSet elements, Document document, IServiceProvider serviceProvider,
-                                      RevitTransactionMode transactionMode)
+                                      RevitTransactionMode transactionMode,
+                                      ILogger? logger = null, string? commandType = null)
     {
         using var transaction = new Transaction(document);
         try
@@ -574,7 +596,7 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
             failureHandlingOptions.SetFailuresPreprocessor(this);
             transaction.SetFailureHandlingOptions(failureHandlingOptions);
 
-            var result = InvokeOnExecute(commandData, elements, serviceProvider);
+            var result = InvokeOnExecute(commandData, elements, serviceProvider, logger, commandType);
 
             // Do not commit on error or in rollback mode.
             if (result == Result.Succeeded && transactionMode == RevitTransactionMode.Transaction)
@@ -627,7 +649,9 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     /// <param name="commandData">The current <see cref="ExternalCommandData" /> instance.</param>
     /// <param name="elements">The <see cref="ElementSet" /> for the current command execution.</param>
     /// <param name="serviceProvider">The scoped <see cref="IServiceProvider" /> for the current command execution.</param>
-    private void InvokeOptionalMethod<TAttribute>(ExternalCommandData commandData, ElementSet elements, IServiceProvider serviceProvider)
+    private void InvokeOptionalMethod<TAttribute>(ExternalCommandData commandData, ElementSet elements,
+                                                   IServiceProvider serviceProvider,
+                                                   ILogger? logger, string? commandType)
         where TAttribute : Attribute
     {
         var method = RevitReflectionHelper.FindSingleAttributedMethod<TAttribute>(GetType(), typeof(RevitCommand), typeof(void));
@@ -635,6 +659,10 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
         {
             return;
         }
+
+        logger?.LogDebug(
+            "Command {CommandType}: invoking [{AttributeName}]-attributed method '{DeclaringType}.{Method}'.",
+            commandType, typeof(TAttribute).Name, method.DeclaringType?.Name, method.Name);
 
         RevitReflectionHelper.Invoke(this, method, serviceProvider,
             new Dictionary<Type, object>
@@ -656,13 +684,18 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
     /// <param name="elements">The <see cref="ElementSet" /> for the current command execution.</param>
     /// <param name="serviceProvider">The scoped <see cref="IServiceProvider" /> for the current command execution.</param>
     /// <returns>A <see cref="Result" /> indicating the outcome of the command execution.</returns>
-    private Result InvokeOnExecute(ExternalCommandData commandData, ElementSet elements, IServiceProvider serviceProvider)
+    private Result InvokeOnExecute(ExternalCommandData commandData, ElementSet elements,
+                                    IServiceProvider serviceProvider,
+                                    ILogger? logger, string? commandType)
     {
-
         // Prefer a method explicitly marked with [RevitCommandExecute].
         var attributedExecute = RevitReflectionHelper.FindSingleAttributedMethod<RevitCommandExecuteAttribute>(GetType(), typeof(RevitCommand), typeof(Result));
         if (attributedExecute is not null)
         {
+            logger?.LogDebug(
+                "Command {CommandType}: dispatching via [{AttributeName}]-attributed method '{DeclaringType}.{Method}'.",
+                commandType, nameof(RevitCommandExecuteAttribute), attributedExecute.DeclaringType?.Name, attributedExecute.Name);
+
             return (Result)RevitReflectionHelper.Invoke(this, attributedExecute, serviceProvider,
                 new Dictionary<Type, object>
                 {
@@ -681,10 +714,20 @@ public abstract class RevitCommand : IExternalCommand, IFailuresPreprocessor, IF
 
         if (elementSetOverride is not null)
         {
+            logger?.LogDebug(
+                "Command {CommandType}: dispatching via standard override '{DeclaringType}.{Method}'.",
+                commandType, elementSetOverride.DeclaringType?.Name, elementSetOverride.Name);
+
             return OnExecute(commandData, elements);
         }
 
         // Fall back to the obsolete overload for backward compatibility.
+        logger?.LogWarning(
+            "Command {CommandType}: no [{AttributeName}]-attributed method or standard OnExecute override found. "
+            + "Falling back to the obsolete OnExecute(ExternalCommandData, IServiceProvider) overload. "
+            + "Migrate to a [{AttributeName}]-attributed method or override OnExecute(ExternalCommandData, ElementSet) instead.",
+            commandType, nameof(RevitCommandExecuteAttribute));
+
 #pragma warning disable CS0618
         return OnExecute(commandData, serviceProvider);
 #pragma warning restore CS0618

--- a/Source/Scotec.Revit/RevitUpdater.cs
+++ b/Source/Scotec.Revit/RevitUpdater.cs
@@ -11,6 +11,7 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Scotec.Revit;
 
@@ -113,7 +114,29 @@ public abstract class RevitUpdater : IUpdater, IDisposable
                               });
 
         var serviceProvider = scope.Resolve<IServiceProvider>();
-        InvokeOnExecute(data, serviceProvider);
+        var logger = serviceProvider.GetService<ILogger<RevitUpdater>>();
+        var updaterType = GetType().FullName;
+        var documentPath = data.GetDocument().PathName;
+
+        logger?.LogDebug(
+            "Updater {UpdaterType}: executing. Document: '{DocumentPath}'.",
+            updaterType, documentPath);
+
+        try
+        {
+            InvokeOnExecute(data, serviceProvider, logger, updaterType);
+
+            logger?.LogInformation(
+                "Updater {UpdaterType}: execution completed. Document: '{DocumentPath}'.",
+                updaterType, documentPath);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex,
+                "Updater {UpdaterType}: unhandled exception during execution. Document: '{DocumentPath}'.",
+                updaterType, documentPath);
+            throw;
+        }
     }
 
     /// <inheritdoc />
@@ -187,11 +210,16 @@ public abstract class RevitUpdater : IUpdater, IDisposable
     ///     <see cref="OnExecute(Autodesk.Revit.DB.UpdaterData)" />.
     ///     Throws <see cref="System.InvalidOperationException" /> if more than one method carries the attribute.
     /// </summary>
-    private void InvokeOnExecute(UpdaterData data, IServiceProvider serviceProvider)
+    private void InvokeOnExecute(UpdaterData data, IServiceProvider serviceProvider,
+                                  ILogger? logger, string? updaterType)
     {
         var attributedExecute = RevitReflectionHelper.FindSingleAttributedMethod<RevitUpdaterExecuteAttribute>(GetType(), typeof(RevitUpdater), typeof(void));
         if (attributedExecute is not null)
         {
+            logger?.LogDebug(
+                "Updater {UpdaterType}: dispatching via [{AttributeName}]-attributed method '{DeclaringType}.{Method}'.",
+                updaterType, nameof(RevitUpdaterExecuteAttribute), attributedExecute.DeclaringType?.Name, attributedExecute.Name);
+
             RevitReflectionHelper.Invoke(this, attributedExecute, serviceProvider,
                 new Dictionary<Type, object>
                 {
@@ -200,6 +228,10 @@ public abstract class RevitUpdater : IUpdater, IDisposable
                 });
             return;
         }
+
+        logger?.LogDebug(
+            "Updater {UpdaterType}: no [{AttributeName}]-attributed method found. Dispatching via virtual OnExecute.",
+            updaterType, nameof(RevitUpdaterExecuteAttribute));
 
         OnExecute(data);
     }


### PR DESCRIPTION
## What Changed

Structured logging has been added to all primary Revit entry-point base classes
using `Microsoft.Extensions.Logging`. The `ILogger<T>` instance is resolved from
the per-invocation `IServiceProvider` inside `private` framework-controlled methods
only — it is never stored as an instance field, injected into a constructor, or
passed as a parameter to any `virtual` or `abstract` method.

## Feature Implemented

- **`RevitAppBase.InvokeLifecycleMethod`** — `Debug` on lifecycle method entry and
  dispatch path selection (attributed method, standard override, or obsolete
  fallback); `Information` on success; `Warning` on obsolete fallback with migration
  guidance; `Error` on unhandled exception, with rethrow.

- **`RevitCommand`** — `Debug` on execution start (command type, document path,
  transaction mode), dispatch path selection (`[RevitCommandExecute]`-attributed,
  standard override, obsolete fallback), and `[RevitCommandBeforeExecute]` /
  `[RevitCommandAfterExecute]` lifecycle invocations; `Information` on completion
  with result; `Warning` on obsolete dispatch fallback with migration guidance;
  `Error` on unhandled exception.

- **`RevitEventHandler`** — `Debug` on handler entry (handler type, event args
  type), dispatch path selection (delegate, `[RevitEventHandlerExecute]`-attributed,
  virtual `OnExecute` fallback); `Information` on success; `Error` on unhandled
  exception. Additionally, `rootLogger` (resolved from the root `IServiceProvider`
  before scope creation) is used to log `Error` if scope creation fails — a failure
  mode that occurs before the per-invocation `serviceProvider` is available.

- **`RevitUpdater`** — `Debug` on execution start (updater type, document path) and
  dispatch path selection (`[RevitUpdaterExecute]`-attributed or virtual `OnExecute`
  fallback); `Information` on completion; `Error` on unhandled exception.

## Risks

- Logger resolution via `GetService<ILogger<T>>()` is nullable — if no logging
  provider is registered, all log calls are silently skipped. This is by design and
  consistent with `Microsoft.Extensions.Logging` conventions.
- `RevitEventHandler` now resolves a `rootLogger` from the root provider before
  scope creation. If the root provider is unavailable, `RevitAppBase.GetServiceProvider()`
  throws before logging is attempted — this is existing behavior, unchanged.