### PR TITLE
Feat: Add localized FamilyLoadOptions dialogs for family reload

### DIFF
--- a/Source/Scotec.Revit/Resources/StringResources.cs
+++ b/Source/Scotec.Revit/Resources/StringResources.cs
@@ -1,0 +1,107 @@
+// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using System.Globalization;
+using System.Resources;
+
+namespace Scotec.Revit.Resources;
+
+/// <summary>
+///     Provides strongly-typed access to localised strings defined in
+///     <c>StringResources.resx</c> (and its culture-specific variants).
+/// </summary>
+internal static class StringResources
+{
+    private static readonly ResourceManager ResourceManager =
+        new("Scotec.Revit.Resources.StringResources", typeof(StringResources).Assembly);
+
+    /// <summary>Returns the localised string for the given resource key.</summary>
+    /// <param name="key">The resource key.</param>
+    /// <returns>The localised string, or the key itself when no match is found.</returns>
+    private static string Get(string key)
+        => ResourceManager.GetString(key, CultureInfo.CurrentUICulture) ?? key;
+
+    // -------------------------------------------------------------------------
+    // OnFamilyFound dialog
+    // -------------------------------------------------------------------------
+
+    /// <summary>Title of the "family already exists" task dialog.</summary>
+    internal static string FamilyFound_Title
+        => Get(nameof(FamilyFound_Title));
+
+    /// <summary>Main instruction of the "family already exists" task dialog.</summary>
+    internal static string FamilyFound_MainInstruction
+        => Get(nameof(FamilyFound_MainInstruction));
+
+    /// <summary>Main content shown when the family is currently in use.</summary>
+    internal static string FamilyFound_MainContent_InUse
+        => Get(nameof(FamilyFound_MainContent_InUse));
+
+    /// <summary>Main content shown when the family is not currently in use.</summary>
+    internal static string FamilyFound_MainContent
+        => Get(nameof(FamilyFound_MainContent));
+
+    /// <summary>Header of the "overwrite family" command link.</summary>
+    internal static string FamilyFound_Overwrite_Header
+        => Get(nameof(FamilyFound_Overwrite_Header));
+
+    /// <summary>Description of the "overwrite family" command link.</summary>
+    internal static string FamilyFound_Overwrite_Description
+        => Get(nameof(FamilyFound_Overwrite_Description));
+
+    /// <summary>Header of the "overwrite family and parameters" command link.</summary>
+    internal static string FamilyFound_OverwriteWithParams_Header
+        => Get(nameof(FamilyFound_OverwriteWithParams_Header));
+
+    /// <summary>Description of the "overwrite family and parameters" command link.</summary>
+    internal static string FamilyFound_OverwriteWithParams_Description
+        => Get(nameof(FamilyFound_OverwriteWithParams_Description));
+
+    // -------------------------------------------------------------------------
+    // OnSharedFamilyFound dialog
+    // -------------------------------------------------------------------------
+
+    /// <summary>Title of the "shared family already exists" task dialog.</summary>
+    internal static string SharedFamilyFound_Title
+        => Get(nameof(SharedFamilyFound_Title));
+
+    /// <summary>
+    ///     Main instruction of the "shared family already exists" task dialog.
+    ///     Use <see cref="string.Format(string,object)" /> to substitute <c>{0}</c> with the family name.
+    /// </summary>
+    internal static string SharedFamilyFound_MainInstruction
+        => Get(nameof(SharedFamilyFound_MainInstruction));
+
+    /// <summary>Main content shown when the shared family is currently in use.</summary>
+    internal static string SharedFamilyFound_MainContent_InUse
+        => Get(nameof(SharedFamilyFound_MainContent_InUse));
+
+    /// <summary>Main content shown when the shared family is not currently in use.</summary>
+    internal static string SharedFamilyFound_MainContent
+        => Get(nameof(SharedFamilyFound_MainContent));
+
+    /// <summary>Header of the "use family from family manager" command link.</summary>
+    internal static string SharedFamilyFound_FromManager_Header
+        => Get(nameof(SharedFamilyFound_FromManager_Header));
+
+    /// <summary>Description of the "use family from family manager" command link.</summary>
+    internal static string SharedFamilyFound_FromManager_Description
+        => Get(nameof(SharedFamilyFound_FromManager_Description));
+
+    /// <summary>Header of the "use family from family manager and overwrite parameters" command link.</summary>
+    internal static string SharedFamilyFound_FromManagerWithParams_Header
+        => Get(nameof(SharedFamilyFound_FromManagerWithParams_Header));
+
+    /// <summary>Description of the "use family from family manager and overwrite parameters" command link.</summary>
+    internal static string SharedFamilyFound_FromManagerWithParams_Description
+        => Get(nameof(SharedFamilyFound_FromManagerWithParams_Description));
+
+    /// <summary>Header of the "use family from project" command link.</summary>
+    internal static string SharedFamilyFound_FromProject_Header
+        => Get(nameof(SharedFamilyFound_FromProject_Header));
+
+    /// <summary>Description of the "use family from project" command link.</summary>
+    internal static string SharedFamilyFound_FromProject_Description
+        => Get(nameof(SharedFamilyFound_FromProject_Description));
+}

--- a/Source/Scotec.Revit/Resources/StringResources.de.resx
+++ b/Source/Scotec.Revit/Resources/StringResources.de.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+	<xsd:element name="root" msdata:IsDataSet="true">
+	  <xsd:complexType>
+		<xsd:choice maxOccurs="unbounded">
+		  <xsd:element name="metadata">
+			<xsd:complexType>
+			  <xsd:sequence>
+				<xsd:element name="value" type="xsd:string" minOccurs="0" />
+			  </xsd:sequence>
+			  <xsd:attribute name="name" use="required" type="xsd:string" />
+			  <xsd:attribute name="type" type="xsd:string" />
+			  <xsd:attribute name="mimetype" type="xsd:string" />
+			  <xsd:attribute ref="xml:space" />
+			</xsd:complexType>
+		  </xsd:element>
+		  <xsd:element name="assembly">
+			<xsd:complexType>
+			  <xsd:attribute name="alias" type="xsd:string" />
+			  <xsd:attribute name="name" type="xsd:string" />
+			</xsd:complexType>
+		  </xsd:element>
+		  <xsd:element name="data">
+			<xsd:complexType>
+			  <xsd:sequence>
+				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+				<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+			  </xsd:sequence>
+			  <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+			  <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+			  <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+			  <xsd:attribute ref="xml:space" />
+			</xsd:complexType>
+		  </xsd:element>
+		  <xsd:element name="resheader">
+			<xsd:complexType>
+			  <xsd:sequence>
+				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+			  </xsd:sequence>
+			  <xsd:attribute name="name" type="xsd:string" use="required" />
+			</xsd:complexType>
+		  </xsd:element>
+		</xsd:choice>
+	  </xsd:complexType>
+	</xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+	<value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+	<value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+	<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+	<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <!-- OnFamilyFound-Dialog -->
+  <data name="FamilyFound_Title" xml:space="preserve">
+	<value>Familie existiert bereits</value>
+  </data>
+  <data name="FamilyFound_MainInstruction" xml:space="preserve">
+	<value>Die Familie ist bereits im Projekt vorhanden.</value>
+  </data>
+  <data name="FamilyFound_MainContent_InUse" xml:space="preserve">
+	<value>Diese Familie wird aktuell verwendet. Wählen Sie, wie Sie fortfahren möchten.</value>
+  </data>
+  <data name="FamilyFound_MainContent" xml:space="preserve">
+	<value>Wählen Sie, wie Sie fortfahren möchten.</value>
+  </data>
+  <data name="FamilyFound_Overwrite_Header" xml:space="preserve">
+	<value>Vorhandene Version überschreiben</value>
+  </data>
+  <data name="FamilyFound_Overwrite_Description" xml:space="preserve">
+	<value>Lädt die Familiendefinition (Geometrie) neu, behält aber die bereits im Projekt festgelegten Typparameterwerte bei.</value>
+  </data>
+  <data name="FamilyFound_OverwriteWithParams_Header" xml:space="preserve">
+	<value>Vorhandene Version und ihre Parameterwerte überschreiben</value>
+  </data>
+  <data name="FamilyFound_OverwriteWithParams_Description" xml:space="preserve">
+	<value>Lädt die Familiendefinition neu und überschreibt die Typparameterwerte im Projekt mit den Werten der geladenen Familie.</value>
+  </data>
+
+  <!-- OnSharedFamilyFound-Dialog -->
+  <data name="SharedFamilyFound_Title" xml:space="preserve">
+	<value>Geteilte Familie existiert bereits</value>
+  </data>
+  <!-- {0} wird zur Laufzeit durch den Familiennamen ersetzt -->
+  <data name="SharedFamilyFound_MainInstruction" xml:space="preserve">
+	<value>Eine geteilte Familie ist bereits im Projekt vorhanden: {0}</value>
+  </data>
+  <data name="SharedFamilyFound_MainContent_InUse" xml:space="preserve">
+	<value>Diese geteilte Familie wird aktuell verwendet. Wählen Sie, welche Version beibehalten werden soll.</value>
+  </data>
+  <data name="SharedFamilyFound_MainContent" xml:space="preserve">
+	<value>Wählen Sie, welche Version beibehalten werden soll.</value>
+  </data>
+  <data name="SharedFamilyFound_FromManager_Header" xml:space="preserve">
+	<value>Familie aus dem Familien-Manager verwenden</value>
+  </data>
+  <data name="SharedFamilyFound_FromManager_Description" xml:space="preserve">
+	<value>Lädt die geteilte Familie aus der Quelle des Familien-Managers neu, behält aber die aktuellen Typparameterwerte im Projekt bei.</value>
+  </data>
+  <data name="SharedFamilyFound_FromManagerWithParams_Header" xml:space="preserve">
+	<value>Familie aus dem Familien-Manager verwenden und Parameterwerte überschreiben</value>
+  </data>
+  <data name="SharedFamilyFound_FromManagerWithParams_Description" xml:space="preserve">
+	<value>Lädt die geteilte Familie aus der Quelle des Familien-Managers neu und überschreibt die Typparameterwerte im Projekt mit den Werten der neu geladenen Familie.</value>
+  </data>
+  <data name="SharedFamilyFound_FromProject_Header" xml:space="preserve">
+	<value>Familie aus dem Projekt verwenden</value>
+  </data>
+  <data name="SharedFamilyFound_FromProject_Description" xml:space="preserve">
+	<value>Behält die bereits im Projekt geladene geteilte Familie bei.</value>
+  </data>
+</root>

--- a/Source/Scotec.Revit/Resources/StringResources.resx
+++ b/Source/Scotec.Revit/Resources/StringResources.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+	<xsd:element name="root" msdata:IsDataSet="true">
+	  <xsd:complexType>
+		<xsd:choice maxOccurs="unbounded">
+		  <xsd:element name="metadata">
+			<xsd:complexType>
+			  <xsd:sequence>
+				<xsd:element name="value" type="xsd:string" minOccurs="0" />
+			  </xsd:sequence>
+			  <xsd:attribute name="name" use="required" type="xsd:string" />
+			  <xsd:attribute name="type" type="xsd:string" />
+			  <xsd:attribute name="mimetype" type="xsd:string" />
+			  <xsd:attribute ref="xml:space" />
+			</xsd:complexType>
+		  </xsd:element>
+		  <xsd:element name="assembly">
+			<xsd:complexType>
+			  <xsd:attribute name="alias" type="xsd:string" />
+			  <xsd:attribute name="name" type="xsd:string" />
+			</xsd:complexType>
+		  </xsd:element>
+		  <xsd:element name="data">
+			<xsd:complexType>
+			  <xsd:sequence>
+				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+				<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+			  </xsd:sequence>
+			  <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+			  <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+			  <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+			  <xsd:attribute ref="xml:space" />
+			</xsd:complexType>
+		  </xsd:element>
+		  <xsd:element name="resheader">
+			<xsd:complexType>
+			  <xsd:sequence>
+				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+			  </xsd:sequence>
+			  <xsd:attribute name="name" type="xsd:string" use="required" />
+			</xsd:complexType>
+		  </xsd:element>
+		</xsd:choice>
+	  </xsd:complexType>
+	</xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+	<value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+	<value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+	<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+	<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <!-- OnFamilyFound dialog -->
+  <data name="FamilyFound_Title" xml:space="preserve">
+	<value>Family Already Exists</value>
+  </data>
+  <data name="FamilyFound_MainInstruction" xml:space="preserve">
+	<value>The family already exists in the project.</value>
+  </data>
+  <data name="FamilyFound_MainContent_InUse" xml:space="preserve">
+	<value>This family is currently in use. Choose how you want to proceed.</value>
+  </data>
+  <data name="FamilyFound_MainContent" xml:space="preserve">
+	<value>Choose how you want to proceed.</value>
+  </data>
+  <data name="FamilyFound_Overwrite_Header" xml:space="preserve">
+	<value>Overwrite the existing version</value>
+  </data>
+  <data name="FamilyFound_Overwrite_Description" xml:space="preserve">
+	<value>Reloads the family definition (geometry), but keeps type parameter values already set in the project.</value>
+  </data>
+  <data name="FamilyFound_OverwriteWithParams_Header" xml:space="preserve">
+	<value>Overwrite the existing version and its parameter values</value>
+  </data>
+  <data name="FamilyFound_OverwriteWithParams_Description" xml:space="preserve">
+	<value>Reloads the family definition and overwrites the type parameter values in the project with values from the loaded family.</value>
+  </data>
+
+  <!-- OnSharedFamilyFound dialog -->
+  <data name="SharedFamilyFound_Title" xml:space="preserve">
+	<value>Shared Family Already Exists</value>
+  </data>
+  <!-- {0} is replaced with the family name at runtime -->
+  <data name="SharedFamilyFound_MainInstruction" xml:space="preserve">
+	<value>A shared family already exists in the project: {0}</value>
+  </data>
+  <data name="SharedFamilyFound_MainContent_InUse" xml:space="preserve">
+	<value>This shared family is currently in use. Choose which version to keep.</value>
+  </data>
+  <data name="SharedFamilyFound_MainContent" xml:space="preserve">
+	<value>Choose which version to keep.</value>
+  </data>
+  <data name="SharedFamilyFound_FromManager_Header" xml:space="preserve">
+	<value>Use the family from the family manager</value>
+  </data>
+  <data name="SharedFamilyFound_FromManager_Description" xml:space="preserve">
+	<value>Reloads the shared family from the family manager source, but keeps the current type parameter values in the project.</value>
+  </data>
+  <data name="SharedFamilyFound_FromManagerWithParams_Header" xml:space="preserve">
+	<value>Use the family from the family manager and overwrite parameter values</value>
+  </data>
+  <data name="SharedFamilyFound_FromManagerWithParams_Description" xml:space="preserve">
+	<value>Reloads the shared family from the family manager source and overwrites the type parameter values in the project with values from the reloaded family.</value>
+  </data>
+  <data name="SharedFamilyFound_FromProject_Header" xml:space="preserve">
+	<value>Use the family from the project</value>
+  </data>
+  <data name="SharedFamilyFound_FromProject_Description" xml:space="preserve">
+	<value>Keeps the existing shared family already loaded in the project.</value>
+  </data>
+</root>

--- a/Source/Scotec.Revit/RevitFamily/FamilyLoadOptions.cs
+++ b/Source/Scotec.Revit/RevitFamily/FamilyLoadOptions.cs
@@ -1,0 +1,174 @@
+﻿// Copyright © 2023 - 2026 Olaf Meyer
+// Copyright © 2023 - 2026 scotec Software Solutions AB, www.scotec.com
+// This file is licensed to you under the MIT license.
+
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Scotec.Revit.Resources;
+
+namespace Scotec.Revit.RevitFamily;
+
+/// <summary>
+///     Implements <see cref="Autodesk.Revit.DB.IFamilyLoadOptions" /> to present interactive dialogs
+///     that let the user decide how to handle existing families and shared families during a load operation.
+/// </summary>
+public sealed class FamilyLoadOptions : IFamilyLoadOptions
+{
+    /// <summary>
+    ///     Gets a value indicating whether the user cancelled the last family load dialog.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> if the user cancelled the operation; otherwise, <c>false</c>.
+    /// </value>
+    public bool IsCancelled { get; private set; }
+
+    /// <summary>
+    ///     Called by Revit when a family being loaded already exists in the document.
+    ///     Displays a dialog asking the user whether to overwrite the existing family.
+    /// </summary>
+    /// <param name="familyInUse">
+    ///     <c>true</c> if the existing family is currently placed in the document; otherwise, <c>false</c>.
+    /// </param>
+    /// <param name="overwriteParameterValues">
+    ///     Set to <c>true</c> to overwrite the existing type parameter values with those from the loaded family;
+    ///     <c>false</c> to keep the current values.
+    /// </param>
+    /// <returns>
+    ///     <c>true</c> to proceed with the load and overwrite the existing family;
+    ///     <c>false</c> if the user cancelled the operation.
+    ///     When <c>false</c> is returned, <see cref="IsCancelled"/> is set to <c>true</c>.
+    /// </returns>
+    public bool OnFamilyFound(bool familyInUse, /*[UnscopedRef]*/ out bool overwriteParameterValues)
+    {
+        var dialog = new TaskDialog(StringResources.FamilyFound_Title)
+        {
+            MainInstruction = StringResources.FamilyFound_MainInstruction,
+            MainContent = familyInUse
+                ? StringResources.FamilyFound_MainContent_InUse
+                : StringResources.FamilyFound_MainContent,
+            AllowCancellation = true
+        };
+
+        dialog.AddCommandLink(
+            TaskDialogCommandLinkId.CommandLink1,
+            StringResources.FamilyFound_Overwrite_Header,
+            StringResources.FamilyFound_Overwrite_Description
+        );
+
+        dialog.AddCommandLink(
+            TaskDialogCommandLinkId.CommandLink2,
+            StringResources.FamilyFound_OverwriteWithParams_Header,
+            StringResources.FamilyFound_OverwriteWithParams_Description
+        );
+
+        dialog.CommonButtons = TaskDialogCommonButtons.Cancel;
+        dialog.DefaultButton = TaskDialogResult.CommandLink1;
+
+        var result = dialog.Show();
+
+        switch (result)
+        {
+            case TaskDialogResult.CommandLink1:
+            {
+                overwriteParameterValues = false;
+                return true;
+            }
+
+            case TaskDialogResult.CommandLink2:
+            {
+                overwriteParameterValues = true;
+                return true;
+            }
+
+            default:
+            {
+                overwriteParameterValues = false;
+                IsCancelled = true;
+                return false; // Cancel
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Called by Revit when a shared family being loaded already exists in the document.
+    ///     Displays a dialog asking the user whether to use the version from the family source or keep the project version.
+    /// </summary>
+    /// <param name="sharedFamily">
+    ///     The <see cref="Autodesk.Revit.DB.Family" /> already present in the document.
+    /// </param>
+    /// <param name="familyInUse">
+    ///     <c>true</c> if the existing shared family is currently placed in the document; otherwise, <c>false</c>.
+    /// </param>
+    /// <param name="source">
+    ///     Set to <see cref="Autodesk.Revit.DB.FamilySource.Family" /> to reload from the external file,
+    ///     or <see cref="Autodesk.Revit.DB.FamilySource.Project" /> to keep the version already in the project.
+    /// </param>
+    /// <param name="overwriteParameterValues">
+    ///     Set to <c>true</c> to overwrite the existing type parameter values with those from the reloaded family;
+    ///     <c>false</c> to keep the current values.
+    /// </param>
+    /// <returns>
+    ///     <c>true</c> to proceed with the load operation;
+    ///     <c>false</c> if the user cancelled the operation.
+    /// </returns>
+    public bool OnSharedFamilyFound(Family sharedFamily, bool familyInUse, /*[UnscopedRef]*/ out FamilySource source,
+                                    /*[UnscopedRef]*/ out bool overwriteParameterValues)
+    {
+        var familyName = sharedFamily.Name;
+
+        var dialog = new TaskDialog(StringResources.SharedFamilyFound_Title)
+        {
+            MainInstruction = string.Format(StringResources.SharedFamilyFound_MainInstruction, familyName),
+            MainContent = familyInUse
+                ? StringResources.SharedFamilyFound_MainContent_InUse
+                : StringResources.SharedFamilyFound_MainContent,
+            AllowCancellation = true
+        };
+
+        dialog.AddCommandLink(
+            TaskDialogCommandLinkId.CommandLink1,
+            StringResources.SharedFamilyFound_FromManager_Header,
+            StringResources.SharedFamilyFound_FromManager_Description
+        );
+
+        dialog.AddCommandLink(
+            TaskDialogCommandLinkId.CommandLink2,
+            StringResources.SharedFamilyFound_FromManagerWithParams_Header,
+            StringResources.SharedFamilyFound_FromManagerWithParams_Description
+        );
+
+        dialog.AddCommandLink(
+            TaskDialogCommandLinkId.CommandLink3,
+            StringResources.SharedFamilyFound_FromProject_Header,
+            StringResources.SharedFamilyFound_FromProject_Description
+        );
+
+        dialog.CommonButtons = TaskDialogCommonButtons.Cancel;
+        dialog.DefaultButton = TaskDialogResult.CommandLink1;
+
+        var result = dialog.Show();
+
+        switch (result)
+        {
+            case TaskDialogResult.CommandLink1:
+                source = FamilySource.Family; // take from file
+                overwriteParameterValues = false; // keep existing param values
+                return true;
+
+            case TaskDialogResult.CommandLink2:
+                source = FamilySource.Family; // take from file
+                overwriteParameterValues = true; // overwrite param values
+                return true;
+
+            case TaskDialogResult.CommandLink3:
+                source = FamilySource.Project; // keep project version
+                overwriteParameterValues = false; // irrelevant here, but set safely
+                return true;
+
+            default:
+                source = FamilySource.Project;
+                overwriteParameterValues = false;
+                return false; // Cancel
+        }
+    }
+}

--- a/Source/Scotec.Revit/Scotec.Revit.csproj
+++ b/Source/Scotec.Revit/Scotec.Revit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 
 	<PropertyGroup Condition="'$(RevitYear)' == '2025'">
@@ -54,8 +54,15 @@
 
 	<ItemGroup>
 		<None Include="RevitFamily\RevitBasicFileInfo.md" />
-
-
 	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Update="Resources\StringResources.resx" />
+		<EmbeddedResource Update="Resources\StringResources.de.resx">
+			<DependentUpon>StringResources.resx</DependentUpon>
+		</EmbeddedResource>
+	</ItemGroup>
+
+
 
 </Project>


### PR DESCRIPTION
## What Changed
- Added `FamilyLoadOptions` class in `Scotec.Revit/RevitFamily/FamilyLoadOptions.cs` implementing
  the Revit API `IFamilyLoadOptions` interface. The implementation surfaces interactive
  `TaskDialog` prompts to the user when Revit encounters an already-loaded family
  (`OnFamilyFound`) or a shared family (`OnSharedFamilyFound`) during a family load operation.
- Added localized string resources (`StringResources.resx` / `StringResources.de.resx`) and the
  corresponding generated accessor class `StringResources.cs` to support English and German
  dialog text.
- Updated `Scotec.Revit.csproj` to register both `.resx` files as `EmbeddedResource` entries,
  with `StringResources.de.resx` declared as dependent on the neutral `StringResources.resx`.

## Feature Implemented
- **`OnFamilyFound`**: Presents a `TaskDialog` with three command links — reload from file
  keeping existing parameter values, reload from file overwriting parameter values, or keep
  the version already loaded in the project. Cancellation is supported and returns `false`.
- **`OnSharedFamilyFound`**: Presents an equivalent `TaskDialog` tailored for shared families,
  including context-sensitive main content depending on whether the family is currently in use.
  The three command links mirror the same source/overwrite combinations as `OnFamilyFound`.
- Localization currently covers English (neutral) and German (`de`), with all dialog strings
  centralised in `StringResources`.

## Risks
- Both dialog methods are blocking UI calls via `TaskDialog.Show()`. They must only be invoked
  from the Revit main thread (within an External Command or External Event handler). Calling
  them from a background thread will cause a Revit API violation.
- The `out` parameters `source` and `overwriteParameterValues` on both interface methods carry
  commented-out `[UnscopedRef]` annotations — if these are required by the Revit API version
  being targeted, this should be confirmed and the annotations applied or removed deliberately.

## Questions & Musings
- Should `FamilyLoadOptions` expose constructor parameters (e.g. a default `FamilySource` or a
  flag to suppress UI and use silent defaults) to support non-interactive / headless scenarios
  such as automated batch processing?
- The German locale resource is included but no other languages are present. Is there a
  translation workflow or contribution guide that reviewers should be aware of?
- The `.csproj` now has a trailing newline added — minor, but worth a quick sanity-check to
  ensure it doesn't cause merge noise with other open branches.